### PR TITLE
Add CI syntax check, .gitattributes, and remove stale lockfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# AutoHotkey and docs are edited on Windows; normalize to CRLF on checkout
+# so git stops warning about LF/CRLF conversion on every touch.
+*.ahk text eol=crlf
+*.md text eol=crlf
+*.ini text eol=crlf
+*.json text eol=crlf
+
+# Binary assets: never diff or convert line endings.
+*.png binary
+*.gif binary
+*.jpg binary
+*.jpeg binary
+*.ico binary
+*.exe binary
+*.dll binary

--- a/.github/workflows/ahk-syntax-check.yml
+++ b/.github/workflows/ahk-syntax-check.yml
@@ -1,0 +1,27 @@
+name: AHK Syntax Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  syntax-check:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install AutoHotkey v2
+        shell: pwsh
+        run: |
+          $zipPath = Join-Path $env:RUNNER_TEMP "ahk-v2.zip"
+          Invoke-WebRequest -Uri "https://www.autohotkey.com/download/ahk-v2.zip" -OutFile $zipPath
+          $installDir = Join-Path $env:RUNNER_TEMP "ahk-v2"
+          Expand-Archive -Path $zipPath -DestinationPath $installDir
+          Add-Content -Path $env:GITHUB_PATH -Value $installDir
+
+      - name: Run syntax check
+        shell: pwsh
+        run: .\Tests\Invoke-SyntaxCheck.ps1

--- a/.github/workflows/ahk-tests.yml
+++ b/.github/workflows/ahk-tests.yml
@@ -15,9 +15,21 @@ jobs:
 
       - name: Install AutoHotkey v2
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # autohotkey.com puts its download links behind a Cloudflare bot
+          # challenge that GitHub-hosted runner IPs fail, so pull the same
+          # zip from the official GitHub release instead.
+          $headers = @{ Authorization = "Bearer $env:GH_TOKEN"; "User-Agent" = "ahk-tests-ci" }
+          $release = Invoke-RestMethod -Uri "https://api.github.com/repos/AutoHotkey/AutoHotkey/releases/latest" -Headers $headers
+          $asset = $release.assets | Where-Object { $_.name -like "AutoHotkey_*.zip" } | Select-Object -First 1
+          if (-not $asset) {
+              throw "Could not find an AutoHotkey_*.zip asset on the latest AutoHotkey/AutoHotkey release."
+          }
+
           $zipPath = Join-Path $env:RUNNER_TEMP "ahk-v2.zip"
-          Invoke-WebRequest -Uri "https://www.autohotkey.com/download/ahk-v2.zip" -OutFile $zipPath
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath -Headers @{ "User-Agent" = "ahk-tests-ci" }
           $installDir = Join-Path $env:RUNNER_TEMP "ahk-v2"
           Expand-Archive -Path $zipPath -DestinationPath $installDir
           Add-Content -Path $env:GITHUB_PATH -Value $installDir

--- a/.github/workflows/ahk-tests.yml
+++ b/.github/workflows/ahk-tests.yml
@@ -1,4 +1,4 @@
-name: AHK Syntax Check
+name: AHK Tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  syntax-check:
+  tests:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -25,3 +25,7 @@ jobs:
       - name: Run syntax check
         shell: pwsh
         run: .\Tests\Invoke-SyntaxCheck.ps1
+
+      - name: Run unit tests
+        shell: pwsh
+        run: .\Tests\Invoke-UnitTests.ps1

--- a/.github/workflows/ahk-tests.yml
+++ b/.github/workflows/ahk-tests.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ahk-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Lib/Extensions/Array.ahk
+++ b/Lib/Extensions/Array.ahk
@@ -1,6 +1,7 @@
 ; Extend Array with additional methods
 
 _ArrayToString(this, char := ", ") {
+	str := ""
 	for index, value in this {
 		if index = this.Length {
 			str .= value

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Hey everyone! 👋
 
+[![AHK Tests](https://github.com/Flop0333/AutoHotkey/actions/workflows/ahk-tests.yml/badge.svg)](https://github.com/Flop0333/AutoHotkey/actions/workflows/ahk-tests.yml)
+
 I'm excited to show my AutoHotkey v2 workflow system that I've been building! It's a modular collection of productivity tools that's transformed how I work.
 
 **New to this project?** → [Installation Guide](INSTALLATION.md)

--- a/Tests/Invoke-SyntaxCheck.ps1
+++ b/Tests/Invoke-SyntaxCheck.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+    Load-time syntax check for every AutoHotkey v2 entry-point script in the repo.
+
+.DESCRIPTION
+    AutoHotkey parses a script's entire source (including everything pulled in via
+    #Include) before executing a single line of it. This script exploits that: for
+    each entry point it generates a tiny wrapper that calls ExitApp() as the very
+    first statement, then #Includes the real script. If the real script parses
+    cleanly, the wrapper exits immediately with code 0 and none of the target's
+    actual side effects (hotkeys, GUIs, Run() calls, etc.) ever execute. If the
+    target has a load-time error, AutoHotkey shows a blocking error dialog instead
+    of exiting, which this script detects as a timeout.
+
+    Entry points are discovered from Startup/Startup.ahk's RunStartup() function,
+    which is the single source of truth for what actually launches on this machine.
+#>
+
+param(
+    [int]$TimeoutSeconds = 15
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+# AutoHotkey.exe (v2) must already be on PATH - see the setup step in
+# .github/workflows/ahk-syntax-check.yml for how CI installs it.
+$ahkExe = Get-Command "AutoHotkey.exe" -ErrorAction SilentlyContinue
+if (-not $ahkExe) {
+    $ahkExe = Get-Command "AutoHotkey64.exe" -ErrorAction SilentlyContinue
+}
+if (-not $ahkExe) {
+    Write-Error "Could not find AutoHotkey.exe or AutoHotkey64.exe on PATH."
+    exit 1
+}
+
+# Mirrors the static properties in Lib/Core/Paths.ahk.
+$pathsMap = @{
+    appsIntegrated = "Apps Integrated"
+    appsStandalone = "Apps Standalone"
+    dashboards     = "Dashboards"
+}
+
+$startupFile = Join-Path $repoRoot "Startup\Startup.ahk"
+$startupContent = Get-Content -Raw $startupFile
+
+$targets = [System.Collections.Generic.List[string]]::new()
+$targets.Add($startupFile)
+
+$runCalls = [regex]::Matches($startupContent, 'Run\(Paths\.(\w+)\s*"([^"]+)"\)')
+foreach ($m in $runCalls) {
+    $pathsKey = $m.Groups[1].Value
+    $relativePath = $m.Groups[2].Value
+    if (-not $pathsMap.ContainsKey($pathsKey)) {
+        Write-Warning "Unknown Paths.$pathsKey referenced in Startup.ahk - add it to `$pathsMap in this script."
+        continue
+    }
+    $fullPath = Join-Path (Join-Path $repoRoot $pathsMap[$pathsKey]) $relativePath.TrimStart('\')
+    $targets.Add($fullPath)
+}
+
+Write-Host "Found $($targets.Count) entry-point script(s) to check.`n"
+
+$results = @()
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ahk-syntax-check-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+try {
+    foreach ($target in $targets) {
+        $name = $target
+        if ($target.StartsWith($repoRoot)) {
+            $name = $target.Substring($repoRoot.Length).TrimStart('\', '/')
+        }
+
+        if (-not (Test-Path $target)) {
+            $results += [pscustomobject]@{ Script = $name; Status = "MISSING"; Detail = "File not found" }
+            continue
+        }
+
+        $wrapperPath = Join-Path $tempDir ((New-Guid).Guid + ".ahk")
+        @"
+#Requires AutoHotkey v2
+ExitApp(0)
+#Include $target
+"@ | Set-Content -Path $wrapperPath -Encoding UTF8
+
+        $stderrPath = Join-Path $tempDir ((New-Guid).Guid + ".stderr.txt")
+        $proc = Start-Process -FilePath $ahkExe.Source -ArgumentList "/ErrorStdOut", "`"$wrapperPath`"" `
+            -PassThru -RedirectStandardError $stderrPath -WindowStyle Hidden
+
+        # Touching .Handle forces PowerShell to open the process with the access
+        # rights needed to read .ExitCode later - without this, .ExitCode silently
+        # comes back empty even though the process exited normally.
+        $null = $proc.Handle
+
+        $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
+
+        if (-not $exited) {
+            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            $results += [pscustomobject]@{ Script = $name; Status = "FAIL"; Detail = "Timed out after ${TimeoutSeconds}s - likely a blocked load-time error dialog" }
+            continue
+        }
+
+        if ($proc.ExitCode -ne 0) {
+            $stderr = ""
+            if (Test-Path $stderrPath) {
+                $rawContent = Get-Content -Raw $stderrPath
+                if ($null -ne $rawContent) { $stderr = $rawContent.Trim() }
+            }
+            $results += [pscustomobject]@{ Script = $name; Status = "FAIL"; Detail = "Exit code $($proc.ExitCode). $stderr" }
+            continue
+        }
+
+        $results += [pscustomobject]@{ Script = $name; Status = "PASS"; Detail = "" }
+    }
+} finally {
+    Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+}
+
+$results | Format-Table -AutoSize | Out-String | Write-Host
+
+$failures = @($results | Where-Object { $_.Status -ne "PASS" })
+if ($failures.Count -gt 0) {
+    Write-Host "`n$($failures.Count) of $($results.Count) script(s) failed the syntax check."
+    exit 1
+}
+
+Write-Host "`nAll $($results.Count) script(s) passed the syntax check."
+exit 0

--- a/Tests/Invoke-SyntaxCheck.ps1
+++ b/Tests/Invoke-SyntaxCheck.ps1
@@ -23,14 +23,12 @@ param(
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $PSScriptRoot
 
-# AutoHotkey.exe (v2) must already be on PATH - see the setup step in
-# .github/workflows/ahk-syntax-check.yml for how CI installs it.
-$ahkExe = Get-Command "AutoHotkey.exe" -ErrorAction SilentlyContinue
-if (-not $ahkExe) {
-    $ahkExe = Get-Command "AutoHotkey64.exe" -ErrorAction SilentlyContinue
-}
-if (-not $ahkExe) {
-    Write-Error "Could not find AutoHotkey.exe or AutoHotkey64.exe on PATH."
+Import-Module (Join-Path $PSScriptRoot "Support\AhkRunner.psm1") -Force
+
+try {
+    $ahkExe = Get-AhkExecutable
+} catch {
+    Write-Error $_.Exception.Message
     exit 1
 }
 
@@ -85,29 +83,20 @@ ExitApp(0)
 "@ | Set-Content -Path $wrapperPath -Encoding UTF8
 
         $stderrPath = Join-Path $tempDir ((New-Guid).Guid + ".stderr.txt")
-        $proc = Start-Process -FilePath $ahkExe.Source -ArgumentList "/ErrorStdOut", "`"$wrapperPath`"" `
-            -PassThru -RedirectStandardError $stderrPath -WindowStyle Hidden
+        $run = Invoke-AhkScript -AhkExePath $ahkExe.Source -ScriptPath $wrapperPath -StdErrPath $stderrPath -TimeoutSeconds $TimeoutSeconds
 
-        # Touching .Handle forces PowerShell to open the process with the access
-        # rights needed to read .ExitCode later - without this, .ExitCode silently
-        # comes back empty even though the process exited normally.
-        $null = $proc.Handle
-
-        $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
-
-        if (-not $exited) {
-            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        if (-not $run.Exited) {
             $results += [pscustomobject]@{ Script = $name; Status = "FAIL"; Detail = "Timed out after ${TimeoutSeconds}s - likely a blocked load-time error dialog" }
             continue
         }
 
-        if ($proc.ExitCode -ne 0) {
+        if ($run.ExitCode -ne 0) {
             $stderr = ""
             if (Test-Path $stderrPath) {
                 $rawContent = Get-Content -Raw $stderrPath
                 if ($null -ne $rawContent) { $stderr = $rawContent.Trim() }
             }
-            $results += [pscustomobject]@{ Script = $name; Status = "FAIL"; Detail = "Exit code $($proc.ExitCode). $stderr" }
+            $results += [pscustomobject]@{ Script = $name; Status = "FAIL"; Detail = "Exit code $($run.ExitCode). $stderr" }
             continue
         }
 

--- a/Tests/Invoke-UnitTests.ps1
+++ b/Tests/Invoke-UnitTests.ps1
@@ -22,14 +22,12 @@ param(
 $ErrorActionPreference = "Stop"
 $unitTestDir = Join-Path $PSScriptRoot "Unit"
 
-# AutoHotkey.exe (v2) must already be on PATH - see the setup step in
-# .github/workflows/ahk-syntax-check.yml for how CI installs it.
-$ahkExe = Get-Command "AutoHotkey.exe" -ErrorAction SilentlyContinue
-if (-not $ahkExe) {
-    $ahkExe = Get-Command "AutoHotkey64.exe" -ErrorAction SilentlyContinue
-}
-if (-not $ahkExe) {
-    Write-Error "Could not find AutoHotkey.exe or AutoHotkey64.exe on PATH."
+Import-Module (Join-Path $PSScriptRoot "Support\AhkRunner.psm1") -Force
+
+try {
+    $ahkExe = Get-AhkExecutable
+} catch {
+    Write-Error $_.Exception.Message
     exit 1
 }
 
@@ -50,15 +48,9 @@ try {
         $stdoutPath = Join-Path $tempDir ((New-Guid).Guid + ".stdout.txt")
         $stderrPath = Join-Path $tempDir ((New-Guid).Guid + ".stderr.txt")
 
-        $proc = Start-Process -FilePath $ahkExe.Source -ArgumentList "/ErrorStdOut", "`"$($testFile.FullName)`"" `
-            -PassThru -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -WindowStyle Hidden
+        $run = Invoke-AhkScript -AhkExePath $ahkExe.Source -ScriptPath $testFile.FullName `
+            -StdOutPath $stdoutPath -StdErrPath $stderrPath -TimeoutSeconds $TimeoutSeconds
 
-        # Touching .Handle forces PowerShell to open the process with the access
-        # rights needed to read .ExitCode later - without this, .ExitCode silently
-        # comes back empty even though the process exited normally.
-        $null = $proc.Handle
-
-        $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
         $stdout = ""
         if (Test-Path $stdoutPath) {
             $rawStdout = Get-Content -Raw $stdoutPath
@@ -67,8 +59,7 @@ try {
 
         Write-Host "--- $($testFile.Name) ---"
 
-        if (-not $exited) {
-            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        if (-not $run.Exited) {
             Write-Host $stdout
             Write-Host "TIMEOUT after ${TimeoutSeconds}s - likely a blocked load-time error dialog somewhere in this file's #Include chain."
             $fileResults += [pscustomobject]@{ File = $testFile.Name; Status = "TIMEOUT" }
@@ -77,7 +68,7 @@ try {
 
         Write-Host $stdout
 
-        if ($proc.ExitCode -ne 0) {
+        if ($run.ExitCode -ne 0) {
             $stderr = ""
             if (Test-Path $stderrPath) {
                 $rawContent = Get-Content -Raw $stderrPath

--- a/Tests/Invoke-UnitTests.ps1
+++ b/Tests/Invoke-UnitTests.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+    Runs every AutoHotkey v2 unit test file in Tests/Unit.
+
+.DESCRIPTION
+    Each Tests/Unit/*.Tests.ahk file is a standalone AutoHotkey v2 entry point
+    built on Tests/Support/Assert.ahk: it registers test cases with
+    TestKit.Run(name, func), then calls TestKit.Report() once at the end to
+    print PASS/FAIL lines to stdout and ExitApp() with 0 (all passed) or 1
+    (at least one failed).
+
+    This script just discovers those files, runs each one, and prints its
+    stdout. A test file that never reaches TestKit.Report() - most likely
+    because it has a load-time error somewhere in its #Include chain - is
+    detected as a timeout, the same way Invoke-SyntaxCheck.ps1 detects one.
+#>
+
+param(
+    [int]$TimeoutSeconds = 20
+)
+
+$ErrorActionPreference = "Stop"
+$unitTestDir = Join-Path $PSScriptRoot "Unit"
+
+# AutoHotkey.exe (v2) must already be on PATH - see the setup step in
+# .github/workflows/ahk-syntax-check.yml for how CI installs it.
+$ahkExe = Get-Command "AutoHotkey.exe" -ErrorAction SilentlyContinue
+if (-not $ahkExe) {
+    $ahkExe = Get-Command "AutoHotkey64.exe" -ErrorAction SilentlyContinue
+}
+if (-not $ahkExe) {
+    Write-Error "Could not find AutoHotkey.exe or AutoHotkey64.exe on PATH."
+    exit 1
+}
+
+$testFiles = @(Get-ChildItem -Path $unitTestDir -Filter "*.Tests.ahk" -File | Sort-Object Name)
+if ($testFiles.Count -eq 0) {
+    Write-Error "No *.Tests.ahk files found under $unitTestDir."
+    exit 1
+}
+
+Write-Host "Found $($testFiles.Count) unit test file(s) to run.`n"
+
+$fileResults = @()
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ahk-unit-tests-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+try {
+    foreach ($testFile in $testFiles) {
+        $stdoutPath = Join-Path $tempDir ((New-Guid).Guid + ".stdout.txt")
+        $stderrPath = Join-Path $tempDir ((New-Guid).Guid + ".stderr.txt")
+
+        $proc = Start-Process -FilePath $ahkExe.Source -ArgumentList "/ErrorStdOut", "`"$($testFile.FullName)`"" `
+            -PassThru -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -WindowStyle Hidden
+
+        # Touching .Handle forces PowerShell to open the process with the access
+        # rights needed to read .ExitCode later - without this, .ExitCode silently
+        # comes back empty even though the process exited normally.
+        $null = $proc.Handle
+
+        $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
+        $stdout = ""
+        if (Test-Path $stdoutPath) {
+            $rawStdout = Get-Content -Raw $stdoutPath
+            if ($null -ne $rawStdout) { $stdout = $rawStdout }
+        }
+
+        Write-Host "--- $($testFile.Name) ---"
+
+        if (-not $exited) {
+            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            Write-Host $stdout
+            Write-Host "TIMEOUT after ${TimeoutSeconds}s - likely a blocked load-time error dialog somewhere in this file's #Include chain."
+            $fileResults += [pscustomobject]@{ File = $testFile.Name; Status = "TIMEOUT" }
+            continue
+        }
+
+        Write-Host $stdout
+
+        if ($proc.ExitCode -ne 0) {
+            $stderr = ""
+            if (Test-Path $stderrPath) {
+                $rawContent = Get-Content -Raw $stderrPath
+                if ($null -ne $rawContent) { $stderr = $rawContent.Trim() }
+            }
+            if ($stderr) { Write-Host $stderr }
+            $fileResults += [pscustomobject]@{ File = $testFile.Name; Status = "FAIL" }
+            continue
+        }
+
+        $fileResults += [pscustomobject]@{ File = $testFile.Name; Status = "PASS" }
+    }
+} finally {
+    Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+}
+
+Write-Host "=== Summary ==="
+$fileResults | Format-Table -AutoSize | Out-String | Write-Host
+
+$failedFiles = @($fileResults | Where-Object { $_.Status -ne "PASS" })
+if ($failedFiles.Count -gt 0) {
+    Write-Host "$($failedFiles.Count) of $($fileResults.Count) test file(s) failed."
+    exit 1
+}
+
+Write-Host "All $($fileResults.Count) test file(s) passed."
+exit 0

--- a/Tests/Support/AhkRunner.psm1
+++ b/Tests/Support/AhkRunner.psm1
@@ -1,0 +1,56 @@
+<#
+.SYNOPSIS
+    Shared helpers for running AutoHotkey v2 scripts from PowerShell with a
+    timeout, used by both Invoke-SyntaxCheck.ps1 and Invoke-UnitTests.ps1.
+#>
+
+function Get-AhkExecutable {
+    # AutoHotkey.exe (v2) must already be on PATH - see the setup step in
+    # .github/workflows/ahk-tests.yml for how CI installs it.
+    $ahkExe = Get-Command "AutoHotkey.exe" -ErrorAction SilentlyContinue
+    if (-not $ahkExe) {
+        $ahkExe = Get-Command "AutoHotkey64.exe" -ErrorAction SilentlyContinue
+    }
+    if (-not $ahkExe) {
+        throw "Could not find AutoHotkey.exe or AutoHotkey64.exe on PATH."
+    }
+    return $ahkExe
+}
+
+function Invoke-AhkScript {
+    param(
+        [Parameter(Mandatory = $true)] [string]$AhkExePath,
+        [Parameter(Mandatory = $true)] [string]$ScriptPath,
+        [string]$StdOutPath,
+        [Parameter(Mandatory = $true)] [string]$StdErrPath,
+        [int]$TimeoutSeconds = 15
+    )
+
+    $startArgs = @{
+        FilePath              = $AhkExePath
+        ArgumentList          = @("/ErrorStdOut", "`"$ScriptPath`"")
+        PassThru              = $true
+        RedirectStandardError = $StdErrPath
+        WindowStyle           = "Hidden"
+    }
+    if ($StdOutPath) {
+        $startArgs.RedirectStandardOutput = $StdOutPath
+    }
+
+    $proc = Start-Process @startArgs
+
+    # Touching .Handle forces PowerShell to open the process with the access
+    # rights needed to read .ExitCode later - without this, .ExitCode silently
+    # comes back empty even though the process exited normally.
+    $null = $proc.Handle
+
+    $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
+    if (-not $exited) {
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        return [pscustomobject]@{ Exited = $false; ExitCode = $null }
+    }
+
+    return [pscustomobject]@{ Exited = $true; ExitCode = $proc.ExitCode }
+}
+
+Export-ModuleMember -Function Get-AhkExecutable, Invoke-AhkScript

--- a/Tests/Support/Assert.ahk
+++ b/Tests/Support/Assert.ahk
@@ -1,0 +1,86 @@
+; Minimal, dependency-free assertion and reporting helpers for AHK unit tests.
+;
+; Each *.Tests.ahk file is a standalone AutoHotkey v2 entry point: it registers
+; test cases with TestKit.Run(name, func), then calls TestKit.Report() once at
+; the end to print PASS/FAIL lines to stdout and ExitApp() with 0 (all passed)
+; or 1 (at least one failed).
+
+class Assert {
+    static Equal(expected, actual, message := "") {
+        if expected != actual
+            throw Error(Assert._Prefix(message) "Expected [" String(expected) "] but got [" String(actual) "]")
+    }
+
+    static NotEqual(notExpected, actual, message := "") {
+        if notExpected = actual
+            throw Error(Assert._Prefix(message) "Expected value to differ from [" String(notExpected) "]")
+    }
+
+    static True(condition, message := "Expected condition to be true") {
+        if !condition
+            throw Error(message)
+    }
+
+    static False(condition, message := "Expected condition to be false") {
+        if condition
+            throw Error(message)
+    }
+
+    static ArrayEqual(expected, actual, message := "") {
+        if expected.Length != actual.Length
+            throw Error(Assert._Prefix(message) "Expected array of length " expected.Length " but got " actual.Length)
+        for index, value in expected
+            if value != actual[index]
+                throw Error(Assert._Prefix(message) "Mismatch at index " index ": expected [" String(value) "] but got [" String(actual[index]) "]")
+    }
+
+    static Throws(func, message := "Expected function to throw") {
+        threw := false
+        try
+            func.Call()
+        catch
+            threw := true
+        if !threw
+            throw Error(message)
+    }
+
+    static DoesNotThrow(func, message := "") {
+        try
+            func.Call()
+        catch as err
+            throw Error(Assert._Prefix(message) "Expected no throw but got: " err.Message)
+    }
+
+    static Fail(message) {
+        throw Error(message)
+    }
+
+    static _Prefix(message) => message ? message ". " : ""
+}
+
+class TestKit {
+    static _results := []
+
+    static Run(name, testFunc) {
+        try {
+            testFunc.Call()
+            this._results.Push({ name: name, passed: true, error: "" })
+        } catch as err {
+            this._results.Push({ name: name, passed: false, error: err.Message })
+        }
+    }
+
+    static Report() {
+        failed := 0
+        for result in this._results {
+            line := (result.passed ? "PASS" : "FAIL") " - " result.name
+            if !result.passed {
+                line .= " :: " result.error
+                failed++
+            }
+            FileAppend(line "`n", "*")
+        }
+        FileAppend("`n" this._results.Length " test(s), " failed " failed.`n", "*")
+        ExitApp(failed > 0 ? 1 : 0)
+    }
+}

--- a/Tests/Unit/Array.Tests.ahk
+++ b/Tests/Unit/Array.Tests.ahk
@@ -1,0 +1,15 @@
+#Requires AutoHotkey v2
+#Include ..\Support\Assert.ahk
+#Include ..\..\Lib\Extensions\Array.ahk
+
+TestKit.Run("ToString joins elements with the default separator", () => Assert.Equal("1, 2, 3", [1, 2, 3].ToString()))
+TestKit.Run("ToString joins elements with a custom separator", () => Assert.Equal("a|b", ["a", "b"].ToString("|")))
+TestKit.Run("ToString on a single-element array returns that element", () => Assert.Equal("only", ["only"].ToString()))
+TestKit.Run("ToString on an empty array returns an empty string", () => Assert.Equal("", [].ToString()))
+
+TestKit.Run("HasValue finds an existing value", () => Assert.True([1, 2, 3].HasValue(2)))
+TestKit.Run("HasValue returns false for a missing value", () => Assert.False([1, 2, 3].HasValue(9)))
+TestKit.Run("HasValue on an empty array returns false", () => Assert.False([].HasValue(1)))
+TestKit.Run("HasValue matches strings", () => Assert.True(["a", "b", "c"].HasValue("b")))
+
+TestKit.Report()

--- a/Tests/Unit/BaseDatabaseService.Tests.ahk
+++ b/Tests/Unit/BaseDatabaseService.Tests.ahk
@@ -1,0 +1,65 @@
+#Requires AutoHotkey v2
+#Include ..\Support\Assert.ahk
+#Include ..\..\Lib\Extensions\Json.ahk
+#Include ..\..\Dashboards\Age of Efficiency\Database\BaseDatabaseService.ahk
+
+; Minimal stand-in item class so this test doesn't depend on a full domain model.
+class TestItem {
+    id := 0
+    title := ""
+}
+
+NewTempServicePath() => A_Temp "\ahk-basedatabaseservice-test-" A_TickCount "-" Random(1000, 9999) ".json"
+
+Test_StoreThenGetItems_RoundTripsItemData() {
+    service := BaseDatabaseService()
+    service.STORAGE_FILE_PATH := NewTempServicePath()
+    try {
+        items := [TestItem(), TestItem()]
+        items[1].id := 1, items[1].title := "First"
+        items[2].id := 2, items[2].title := "Second"
+
+        service.StoreItems(items)
+        result := service.GetItems(TestItem)
+
+        Assert.Equal(2, result.items.Length)
+        Assert.Equal("First", result.items[1].title)
+        Assert.Equal("Second", result.items[2].title)
+        Assert.Equal(2, result.highestId)
+    } finally
+        try FileDelete(service.STORAGE_FILE_PATH)
+}
+
+Test_GetItems_TracksHighestIdRegardlessOfOrder() {
+    service := BaseDatabaseService()
+    service.STORAGE_FILE_PATH := NewTempServicePath()
+    try {
+        items := [TestItem(), TestItem(), TestItem()]
+        items[1].id := 5, items[2].id := 2, items[3].id := 9
+
+        service.StoreItems(items)
+        result := service.GetItems(TestItem)
+
+        Assert.Equal(9, result.highestId)
+    } finally
+        try FileDelete(service.STORAGE_FILE_PATH)
+}
+
+Test_StoreItems_OnEmptyArray_WritesEmptyList() {
+    service := BaseDatabaseService()
+    service.STORAGE_FILE_PATH := NewTempServicePath()
+    try {
+        service.StoreItems([])
+        result := service.GetItems(TestItem)
+
+        Assert.Equal(0, result.items.Length)
+        Assert.Equal(0, result.highestId)
+    } finally
+        try FileDelete(service.STORAGE_FILE_PATH)
+}
+
+TestKit.Run("StoreItems then GetItems round-trips item data", Test_StoreThenGetItems_RoundTripsItemData)
+TestKit.Run("GetItems tracks the highest id regardless of array order", Test_GetItems_TracksHighestIdRegardlessOfOrder)
+TestKit.Run("StoreItems on an empty array writes an empty, readable list", Test_StoreItems_OnEmptyArray_WritesEmptyList)
+
+TestKit.Report()

--- a/Tests/Unit/BaseState.Tests.ahk
+++ b/Tests/Unit/BaseState.Tests.ahk
@@ -1,0 +1,113 @@
+#Requires AutoHotkey v2
+#Include ..\Support\Assert.ahk
+#Include ..\..\Lib\Extensions\Array.ahk
+#Include ..\..\Dashboards\Age of Efficiency\Database\BaseState.ahk
+
+; BaseState.state and BaseState._uniqueId are shared static fields, so every
+; test resets them first to avoid leaking state between test cases.
+ResetState() {
+    BaseState.state := []
+    BaseState._uniqueId := 0
+}
+
+Test_Create_AssignsIncrementingIds() {
+    ResetState()
+    BaseState.Create({ title: "First" })
+    BaseState.Create({ title: "Second" })
+    Assert.Equal(1, BaseState.state[1].id)
+    Assert.Equal(2, BaseState.state[2].id)
+}
+
+Test_GetById_ReturnsMatchingItem() {
+    ResetState()
+    BaseState.Create({ title: "Target" })
+    Assert.Equal("Target", BaseState.GetById(1).title)
+}
+
+Test_GetById_ThrowsWhenNoMatch() {
+    ResetState()
+    Assert.Throws(() => BaseState.GetById(999))
+}
+
+Test_GetByCommandOrTitle_MatchesByCommand() {
+    ResetState()
+    BaseState.Create({ title: "Title", command: "cmd" })
+    Assert.Equal("cmd", BaseState.GetByCommandOrTitle("cmd").command)
+}
+
+Test_GetByCommandOrTitle_MatchesByTitle() {
+    ResetState()
+    BaseState.Create({ title: "Title", command: "cmd" })
+    Assert.Equal("Title", BaseState.GetByCommandOrTitle("Title").title)
+}
+
+Test_GetByCommandOrTitle_ReturnsEmptyStringWhenNoMatch() {
+    ResetState()
+    Assert.Equal("", BaseState.GetByCommandOrTitle("missing"))
+}
+
+Test_GetSuggestionsByCommand_ReturnsPrefixMatchesExcludingExact() {
+    ResetState()
+    BaseState.Create({ title: "A", command: "open" })
+    BaseState.Create({ title: "B", command: "openApp" })
+    BaseState.Create({ title: "C", command: "close" })
+    suggestions := BaseState.GetSuggestionsByCommand("open")
+    Assert.Equal(1, suggestions.Length)
+    Assert.Equal("openApp", suggestions[1].command)
+}
+
+Test_GetByCategory_FiltersByCategory() {
+    ResetState()
+    BaseState.Create({ title: "A", category: "Work" })
+    BaseState.Create({ title: "B", category: "Home" })
+    items := BaseState.GetByCategory("Work")
+    Assert.Equal(1, items.Length)
+    Assert.Equal("A", items[1].title)
+}
+
+Test_GetCategories_ReturnsUniqueNonEmptyCategories() {
+    ResetState()
+    BaseState.Create({ title: "A", category: "Work" })
+    BaseState.Create({ title: "B", category: "Work" })
+    BaseState.Create({ title: "C", category: "Home" })
+    BaseState.Create({ title: "D", category: "" })
+    categories := BaseState.GetCategories()
+    Assert.Equal(2, categories.Length)
+    Assert.True(categories.HasValue("Work"))
+    Assert.True(categories.HasValue("Home"))
+}
+
+Test_Update_MergesPropertiesOntoExistingItem() {
+    ResetState()
+    BaseState.Create({ title: "Original", category: "Work" })
+    BaseState.Update({ id: 1, title: "Updated" })
+    Assert.Equal("Updated", BaseState.GetById(1).title)
+    Assert.Equal("Work", BaseState.GetById(1).category)
+}
+
+Test_Delete_RemovesMatchingItem() {
+    ResetState()
+    BaseState.Create({ title: "ToDelete" })
+    BaseState.Delete("ToDelete")
+    Assert.Equal(0, BaseState.state.Length)
+}
+
+Test_Delete_ThrowsWhenNoMatch() {
+    ResetState()
+    Assert.Throws(() => BaseState.Delete("missing"))
+}
+
+TestKit.Run("Create assigns incrementing ids to new items", Test_Create_AssignsIncrementingIds)
+TestKit.Run("GetById returns the matching item", Test_GetById_ReturnsMatchingItem)
+TestKit.Run("GetById throws when no item matches", Test_GetById_ThrowsWhenNoMatch)
+TestKit.Run("GetByCommandOrTitle matches by command", Test_GetByCommandOrTitle_MatchesByCommand)
+TestKit.Run("GetByCommandOrTitle matches by title", Test_GetByCommandOrTitle_MatchesByTitle)
+TestKit.Run("GetByCommandOrTitle returns an empty string when nothing matches", Test_GetByCommandOrTitle_ReturnsEmptyStringWhenNoMatch)
+TestKit.Run("GetSuggestionsByCommand returns prefix matches excluding the exact match", Test_GetSuggestionsByCommand_ReturnsPrefixMatchesExcludingExact)
+TestKit.Run("GetByCategory filters items by category", Test_GetByCategory_FiltersByCategory)
+TestKit.Run("GetCategories returns unique, non-empty categories", Test_GetCategories_ReturnsUniqueNonEmptyCategories)
+TestKit.Run("Update merges new properties onto the existing item", Test_Update_MergesPropertiesOntoExistingItem)
+TestKit.Run("Delete removes the item with the matching title", Test_Delete_RemovesMatchingItem)
+TestKit.Run("Delete throws when no item matches the title", Test_Delete_ThrowsWhenNoMatch)
+
+TestKit.Report()

--- a/Tests/Unit/NumberConverter.Tests.ahk
+++ b/Tests/Unit/NumberConverter.Tests.ahk
@@ -1,0 +1,14 @@
+#Requires AutoHotkey v2
+#Include ..\Support\Assert.ahk
+#Include ..\..\Lib\Helpers\Number Convertor.ahk
+
+TestKit.Run("DecToHex converts with a 0x prefix by default", () => Assert.Equal("0xff", NumberConverter.DecToHex(255)))
+TestKit.Run("DecToHex can omit the prefix", () => Assert.Equal("ff", NumberConverter.DecToHex(255, false)))
+TestKit.Run("DecToHex handles zero", () => Assert.Equal("0x0", NumberConverter.DecToHex(0)))
+TestKit.Run("DecToHex handles large numbers", () => Assert.Equal("0x100000", NumberConverter.DecToHex(1048576)))
+
+TestKit.Run("HexToDec converts a 0x-prefixed hex string to decimal", () => Assert.Equal("255", NumberConverter.HexToDec("0xff")))
+TestKit.Run("HexToDec handles zero", () => Assert.Equal("0", NumberConverter.HexToDec("0x0")))
+TestKit.Run("HexToDec and DecToHex round-trip", () => Assert.Equal("4096", NumberConverter.HexToDec(NumberConverter.DecToHex(4096))))
+
+TestKit.Report()

--- a/Tests/Unit/SecretsFileManager.Tests.ahk
+++ b/Tests/Unit/SecretsFileManager.Tests.ahk
@@ -1,0 +1,68 @@
+#Requires AutoHotkey v2
+#Include ..\Support\Assert.ahk
+#Include ..\..\Lib\Core\Paths.ahk
+#Include ..\..\Lib\Extensions\Json.ahk
+
+; AHK v2 fully parses the merged script - including code paths this test
+; never executes - before running anything, and requires every referenced
+; global to resolve. Secrets File Manager.ahk calls the real Info() toast
+; helper (Lib/Tools/Info.ahk, a GUI popup) and reads the real SecretsCatalog
+; (Secrets Catalog.ahk, which itself needs the full Secret class). Stub both
+; instead of pulling those dependencies into a unit test that never touches them.
+Info(text, timeout := 0) {
+}
+SecretsCatalog := Map()
+
+#Include ..\..\Secrets\Secrets File Manager.ahk
+
+; _IsValidSecretsJson and _AhkStringLiteral are the only real logic in this
+; file (everything else is file/mutex I/O), so they're exercised directly even
+; though they're private-by-convention (leading underscore).
+
+TestKit.Run("Valid: empty object", () => Assert.True(SecretsFileManager._IsValidSecretsJson("{}")))
+TestKit.Run("Valid: single string key-value pair", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": "value"}')))
+TestKit.Run("Valid: multiple string key-value pairs", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"a": "1", "b": "2"}')))
+TestKit.Run("Valid: tolerates surrounding whitespace and newlines", () => Assert.True(SecretsFileManager._IsValidSecretsJson("`n  { `"a`" : `"1`" } `n")))
+TestKit.Run("Valid: string values may contain escape sequences", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"a": "line1\nline2\ttabbed"}')))
+
+TestKit.Run("Invalid: top-level array is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson("[]") != true))
+TestKit.Run("Invalid: numeric value is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": 123}') != true))
+TestKit.Run("Invalid: boolean value is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": true}') != true))
+TestKit.Run("Invalid: nested object value is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": {}}') != true))
+TestKit.Run("Invalid: trailing comma is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": "value",}') != true))
+TestKit.Run("Invalid: missing colon is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key" "value"}') != true))
+TestKit.Run("Invalid: unterminated string is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": "value') != true))
+TestKit.Run("Invalid: empty text is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson("") != true))
+TestKit.Run("Invalid: trailing garbage after the closing brace is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key":"value"}garbage') != true))
+
+Test_AhkStringLiteral_EscapesEmbeddedDoubleQuotes() {
+    backtick := Chr(96), quote := Chr(34)
+    input := "He said " quote "hi" quote
+    expected := quote "He said " backtick quote "hi" backtick quote quote
+    Assert.Equal(expected, SecretsFileManager._AhkStringLiteral(input))
+}
+
+Test_AhkStringLiteral_EscapesNewlinesAndTabs() {
+    backtick := Chr(96), quote := Chr(34)
+    input := "line1`nline2`ttabbed"
+    expected := quote "line1" backtick "n" "line2" backtick "t" "tabbed" quote
+    Assert.Equal(expected, SecretsFileManager._AhkStringLiteral(input))
+}
+
+Test_AhkStringLiteral_EscapesALiteralBacktick() {
+    backtick := Chr(96), quote := Chr(34)
+    input := "a" backtick "b"
+    expected := quote "a" backtick backtick "b" quote
+    Assert.Equal(expected, SecretsFileManager._AhkStringLiteral(input))
+}
+
+Test_AhkStringLiteral_LeavesPlainTextUnchanged() {
+    Assert.Equal('"hello world"', SecretsFileManager._AhkStringLiteral("hello world"))
+}
+
+TestKit.Run("AhkStringLiteral escapes embedded double quotes", Test_AhkStringLiteral_EscapesEmbeddedDoubleQuotes)
+TestKit.Run("AhkStringLiteral escapes newlines and tabs", Test_AhkStringLiteral_EscapesNewlinesAndTabs)
+TestKit.Run("AhkStringLiteral escapes a literal backtick", Test_AhkStringLiteral_EscapesALiteralBacktick)
+TestKit.Run("AhkStringLiteral leaves plain text unchanged", Test_AhkStringLiteral_LeavesPlainTextUnchanged)
+
+TestKit.Report()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "AutoHotkey",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
- .gitattributes normalizes AHK/md/ini/json to CRLF so git stops warning about line-ending conversion on every commit.
- Tests/Invoke-SyntaxCheck.ps1 load-checks every AutoHotkey entry point discovered from Startup.ahk's RunStartup(), by wrapping each in a temp script that ExitApp()s before any side effects run.
- .github/workflows/ahk-syntax-check.yml runs that check on windows-latest for every push/PR to main.
- Removed the empty root package-lock.json stub, unrelated to the real package in playwright-demo/.