### PR TITLE
Add a Test Dashboard for running the AHK test suites manually

### DIFF
--- a/Dashboards/Age of Efficiency/Database/Apps/Apps.json
+++ b/Dashboards/Age of Efficiency/Database/Apps/Apps.json
@@ -118,5 +118,15 @@
 		"icon": "AutoHotkey",
 		"id": 18,
 		"title": "AutoHotkey Log Dashboard"
+	},
+	{
+		"action": "RunTests",
+		"argument": "",
+		"argumentRequired": 0,
+		"category": "Dev Tools",
+		"command": "Test",
+		"icon": "AutoHotkey",
+		"id": 19,
+		"title": "Run Tests"
 	}
 ]

--- a/Dashboards/Age of Efficiency/Input Handler/Command Methods.ahk
+++ b/Dashboards/Age of Efficiency/Input Handler/Command Methods.ahk
@@ -40,3 +40,6 @@ StartPictureInPicture() => PictureInPicture()
 CloseOnAllDesktops() => DesktopsDDL.CloseOnAllDesktops()
 
 OpenAutoHotkeyDashboard() => ShowLogDashboard()
+
+; RunTests() is defined in Dashboards\Test Dashboard\Test Dashboard.ahk, pulled
+; in transitively via the Startup.ahk include above.

--- a/Dashboards/Test Dashboard/Controller.ahk
+++ b/Dashboards/Test Dashboard/Controller.ahk
@@ -1,0 +1,60 @@
+#Include ..\..\Lib\Core.ahk
+#Include ..\..\Lib\Core\WebView.ahk
+
+Class TestDashboard extends WebViewToo {
+	static WIN_TITLE := "AutoHotkey Test Dashboard"
+	static SHOW_OPTIONS := Format("w{} h{}", Round(A_ScreenWidth * 0.7), Round(A_ScreenHeight * 0.7))
+	static RUNNER_SCRIPT := Paths.autohotkey "\Tests\Invoke-AllTests.ps1"
+	static HISTORY_FILE := Paths.autohotkey "\Logs\test-run-history.log"
+	static STATUS_FILE := Paths.autohotkey "\Logs\test-run-status.json"
+
+	__New() {
+		super.__New()
+		this._ClearHistory()
+		this.Gui.Title := TestDashboard.WIN_TITLE
+		this.Gui.OnEvent("Close", (*) => this.Hide())
+		this.SetVirtualHostNameToFolderMapping("app.local", Paths.dashboards "\Test Dashboard\User Interface", 0) ; block cors error, allow loading local files
+		this.Load("http://app.local/index.html")
+		this.AddCallbackToScript("GetTestRuns", (*) => this.GetTestRunsForWeb())
+		this.AddCallbackToScript("GetStatus", (*) => this.GetStatusForWeb())
+		this.AddCallbackToScript("RunTests", (*) => this.RunTests())
+		this.AddCallbackToScript("SetClipboard", (webview, text) => A_Clipboard := text)
+	}
+
+	Show() => super.Show(TestDashboard.SHOW_OPTIONS, TestDashboard.WIN_TITLE)
+	InitializeHidden() => super.Show("Hide " TestDashboard.SHOW_OPTIONS, TestDashboard.WIN_TITLE)
+
+	Close() => this.Hide()
+
+	; Runs are scoped to this dashboard process's lifetime - a fresh instance
+	; (one per Dashboard.ahk launch, since #SingleInstance Force means there's
+	; only ever one) starts with no history from earlier sessions.
+	_ClearHistory() {
+		try FileDelete(TestDashboard.HISTORY_FILE)
+		try FileDelete(TestDashboard.STATUS_FILE)
+	}
+
+	RunTests() {
+		Run('powershell.exe -NoProfile -ExecutionPolicy Bypass -File "' TestDashboard.RUNNER_SCRIPT '"', , "Hide")
+	}
+
+	GetStatusForWeb() {
+		if !FileExist(TestDashboard.STATUS_FILE)
+			return JSON.Dump(Map("status", "idle"))
+		try return FileRead(TestDashboard.STATUS_FILE, "UTF-8")
+		return JSON.Dump(Map("status", "idle"))
+	}
+
+	GetTestRunsForWeb() {
+		runs := []
+		if !FileExist(TestDashboard.HISTORY_FILE)
+			return JSON.Dump(runs)
+
+		for line in StrSplit(FileRead(TestDashboard.HISTORY_FILE, "UTF-8"), "`n", "`r") {
+			if (Trim(line) = "")
+				continue
+			try runs.Push(JSON.parse(line))
+		}
+		return JSON.Dump(runs)
+	}
+}

--- a/Dashboards/Test Dashboard/Dashboard.ahk
+++ b/Dashboards/Test Dashboard/Dashboard.ahk
@@ -1,0 +1,9 @@
+#SingleInstance Force
+Persistent(true)
+
+TraySetIcon(Paths.autoHotkeyIcon)
+
+myTestDashboard := TestDashboard()
+myTestDashboard.InitializeHidden()
+
+#Include Test Dashboard.ahk

--- a/Dashboards/Test Dashboard/Test Dashboard.ahk
+++ b/Dashboards/Test Dashboard/Test Dashboard.ahk
@@ -1,0 +1,71 @@
+; ============================================================================
+; Test Dashboard - Runs the AutoHotkey test suites and reviews the results
+; ============================================================================
+;
+; [FEATURES]
+;   - "Run All Tests" button runs the syntax check, unit tests, and
+;     integration tests in one pass (see Tests\Invoke-AllTests.ps1)
+;   - Pass/fail history read from Logs\test-run-history.log
+;   - Web-based frontend using WebView2
+;
+; [USAGE]
+;   - Opened via the tray menu's "Test Dashboard" item
+;   - Or run Tests\Run-Tests.ahk to kick off a run and open the dashboard in
+;     one step
+; ============================================================================
+
+#Include ..\..\Lib\Core.ahk
+#Include Controller.ahk
+
+ShowTestDashboard() {
+	dashboardWindow := FindTestDashboardWindow()
+	if !dashboardWindow {
+		StartTestDashboard()
+		dashboardWindow := WaitForTestDashboardWindow()
+	}
+	if dashboardWindow {
+		WinShow("ahk_id " dashboardWindow)
+		WinActivate("ahk_id " dashboardWindow)
+	}
+	return dashboardWindow
+}
+
+HideTestDashboard() {
+	if dashboardWindow := FindTestDashboardWindow()
+		try WinHide("ahk_id " dashboardWindow)
+}
+
+FindTestDashboardWindow() {
+	hiddenWindowsWereDetected := A_DetectHiddenWindows
+	previousTitleMatchMode := A_TitleMatchMode
+	DetectHiddenWindows(true)
+	SetTitleMatchMode(3)
+	dashboardWindow := WinExist(TestDashboard.WIN_TITLE)
+	SetTitleMatchMode(previousTitleMatchMode)
+	DetectHiddenWindows(hiddenWindowsWereDetected)
+	return dashboardWindow
+}
+
+StartTestDashboard() {
+	dashboardScript := Paths.dashboards "\Test Dashboard\Dashboard.ahk"
+	Run('"' A_AhkPath '" "' dashboardScript '"')
+}
+
+; Shared by the Apps.json "Test" command (see Command Methods.ahk) and the
+; tray menu's "Run Tests" item - opens the dashboard and kicks off a run.
+RunTests() {
+	ShowTestDashboard()
+	Run('powershell.exe -NoProfile -ExecutionPolicy Bypass -File "' TestDashboard.RUNNER_SCRIPT '"', , "Hide")
+}
+
+; A generous timeout - WebView2 first-run init (extracting the loader, spinning
+; up its child process) can take several seconds on a cold/slow machine.
+WaitForTestDashboardWindow(timeoutMs := 20000) {
+	startedAt := A_TickCount
+	while (A_TickCount - startedAt < timeoutMs) {
+		if dashboardWindow := FindTestDashboardWindow()
+			return dashboardWindow
+		Sleep(25)
+	}
+	return 0
+}

--- a/Dashboards/Test Dashboard/User Interface/AhkDataService.js
+++ b/Dashboards/Test Dashboard/User Interface/AhkDataService.js
@@ -1,0 +1,10 @@
+class AhkDataService {
+
+  static GetTestRuns = () => JSON.parse(ahk.sync.GetTestRuns());
+
+  static GetStatus = () => JSON.parse(ahk.sync.GetStatus());
+
+  static RunTests = () => ahk.RunTests();
+
+  static SetClipboard = (text) => ahk.SetClipboard(text);
+}

--- a/Dashboards/Test Dashboard/User Interface/index.html
+++ b/Dashboards/Test Dashboard/User Interface/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Test Dashboard</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="title-bar">
+    <div class="drag-region" onmousedown="ahk.DragWindow()">
+      <span class="title-text">Test Dashboard</span>
+    </div>
+    <div class="title-btn-container">
+      <span class="title-btn" onclick="ahk.Minimize()">0</span>
+      <span class="title-btn title-btn-maximize" onclick="ahk.Maximize()">1</span>
+      <span class="title-btn title-btn-close" onclick="ahk.Close()">r</span>
+    </div>
+  </div>
+  <div class="toolbar">
+    <button id="run-tests-btn">Run All Tests</button>
+    <span id="run-count"></span>
+  </div>
+  <div id="status-banner" class="status-banner" hidden>
+    <span class="spinner"></span>
+    <span>Running all tests&hellip; this can take a minute.</span>
+  </div>
+  <div class="layout">
+    <table id="run-table">
+      <thead>
+        <tr><th>Time</th><th>Result</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <div id="detail-panel">
+      <p class="empty-state">Select a run to see suite results.</p>
+    </div>
+  </div>
+  <div id="toast"></div>
+  <script src="index.js"></script>
+  <script src="AhkDataService.js"></script>
+</body>
+</html>

--- a/Dashboards/Test Dashboard/User Interface/index.js
+++ b/Dashboards/Test Dashboard/User Interface/index.js
@@ -1,0 +1,194 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+	new TestDashboardView().render();
+});
+
+class TestDashboardView {
+
+	static POLL_INTERVAL_MS = 1000; // matches Dashboards/Log Dashboard's own polling cadence
+
+	constructor() {
+		this.runs = AhkDataService.GetTestRuns();
+		this.selectedTimestamp = null;
+		this.isRunning = false;
+		this.tableBody = document.querySelector('#run-table tbody');
+		this.detailPanel = document.querySelector('#detail-panel');
+		this.statusBanner = document.querySelector('#status-banner');
+		this.runCount = document.querySelector('#run-count');
+		this.runTestsBtn = document.querySelector('#run-tests-btn');
+		this.toast = document.querySelector('#toast');
+	}
+
+	render() {
+		this._attachEvents();
+		this._renderRows();
+		this._checkStatus();
+		setInterval(() => this._checkStatus(), TestDashboardView.POLL_INTERVAL_MS);
+	}
+
+	_attachEvents() {
+		this.runTestsBtn.addEventListener('click', () => {
+			AhkDataService.RunTests();
+			// Don't wait for the next poll tick - reflect the running state
+			// immediately so the click feels responsive.
+			if (!this.isRunning) {
+				this.isRunning = true;
+				this._enterRunningState();
+			}
+		});
+	}
+
+	// Polls run status (same cadence as Log Dashboard's entry polling) so the
+	// UI reflects a run kicked off from here, from the tray menu, or from
+	// Tests\Run-Tests.ahk directly.
+	_checkStatus() {
+		let status;
+		try {
+			status = AhkDataService.GetStatus();
+		} catch (e) {
+			return;
+		}
+
+		const isRunning = status.status === 'running';
+
+		if (isRunning && !this.isRunning) {
+			this.isRunning = true;
+			this._enterRunningState();
+		} else if (!isRunning && this.isRunning) {
+			this.isRunning = false;
+			this._exitRunningState(status);
+		}
+	}
+
+	_enterRunningState() {
+		this.runTestsBtn.disabled = true;
+		this.runTestsBtn.textContent = 'Running…';
+		this.statusBanner.hidden = false;
+		this._renderRows();
+	}
+
+	_exitRunningState(status) {
+		this.runTestsBtn.disabled = false;
+		this.runTestsBtn.textContent = 'Run All Tests';
+		this.statusBanner.hidden = true;
+		this.runs = AhkDataService.GetTestRuns();
+		this._renderRows();
+		this._selectLatestRun();
+		this._showToast(status.lastRunStatus === 'PASS' ? 'All tests passed' : 'Some tests failed');
+	}
+
+	_selectLatestRun() {
+		const latest = this._sortedRuns()[0];
+		if (!latest)
+			return;
+		const row = [...this.tableBody.querySelectorAll('tr')].find(r => r.dataset.timestamp === latest.timestamp);
+		if (row)
+			this._showDetail(latest, row);
+	}
+
+	_sortedRuns() {
+		return [...this.runs].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+	}
+
+	_createPendingRow() {
+		const row = document.createElement('tr');
+		row.className = 'run-row-pending';
+		row.innerHTML = `<td colspan="2"><span class="spinner"></span> Running tests&hellip;</td>`;
+		return row;
+	}
+
+	_formatTime(timestamp) {
+		const date = new Date(timestamp);
+		return isNaN(date) ? timestamp : date.toLocaleString();
+	}
+
+	_renderRows() {
+		const rows = this._sortedRuns();
+		this.runCount.textContent = `${rows.length} run${rows.length === 1 ? '' : 's'} this session`
+			+ (this.isRunning ? ' · 1 running' : '');
+		this.tableBody.innerHTML = '';
+
+		if (this.isRunning)
+			this.tableBody.appendChild(this._createPendingRow());
+
+		if (!rows.length) {
+			if (!this.isRunning)
+				this.tableBody.innerHTML = '<tr><td colspan="2" class="empty-state">No test runs yet this session. Click "Run All Tests" to start one.</td></tr>';
+			return;
+		}
+
+		rows.forEach(run => {
+			const row = document.createElement('tr');
+			row.dataset.timestamp = run.timestamp;
+			row.innerHTML = `
+				<td>${this._escape(this._formatTime(run.timestamp))}</td>
+				<td class="result result-${this._escape(run.overallStatus)}">${this._escape(run.overallStatus)}</td>
+			`;
+			row.addEventListener('click', () => this._showDetail(run, row));
+			if (run.timestamp === this.selectedTimestamp)
+				row.classList.add('selected');
+			this.tableBody.appendChild(row);
+		});
+	}
+
+	_showDetail(run, row) {
+		this.tableBody.querySelectorAll('tr').forEach(r => r.classList.remove('selected'));
+		row.classList.add('selected');
+		this.selectedTimestamp = run.timestamp;
+
+		const suitesHtml = run.suites.map(suite => `
+			<div class="suite">
+				<div class="suite-header">
+					<h3 class="result-${this._escape(suite.status)}">${this._escape(suite.name)}: ${this._escape(suite.status)}</h3>
+					<button class="copy-btn" data-suite="${this._escape(suite.name)}" title="Copy this suite's output">📋 Copy</button>
+				</div>
+				<pre>${this._escape(suite.output || '(no output)')}</pre>
+			</div>
+		`).join('');
+
+		this.detailPanel.innerHTML = `
+			<div class="detail-header">
+				<h2 class="result-${this._escape(run.overallStatus)}">${this._escape(run.overallStatus)} — ${this._escape(this._formatTime(run.timestamp))}</h2>
+				<button class="copy-btn" id="copy-run-btn" title="Copy the full run log">📋 Copy All</button>
+			</div>
+			${suitesHtml}
+		`;
+
+		this.detailPanel.querySelector('#copy-run-btn').addEventListener('click', () => {
+			this._copyToClipboard(this._formatFullLog(run), 'Full run log copied to clipboard');
+		});
+		this.detailPanel.querySelectorAll('.copy-btn[data-suite]').forEach(button => {
+			button.addEventListener('click', () => {
+				const suite = run.suites.find(s => s.name === button.dataset.suite);
+				this._copyToClipboard(this._formatSuiteLog(suite), `${suite.name} output copied to clipboard`);
+			});
+		});
+	}
+
+	_formatSuiteLog(suite) {
+		return `${suite.name}: ${suite.status}\n${suite.output || '(no output)'}`;
+	}
+
+	_formatFullLog(run) {
+		const suiteLogs = run.suites.map(s => this._formatSuiteLog(s)).join('\n\n');
+		return `Test run ${this._formatTime(run.timestamp)} — ${run.overallStatus}\n\n${suiteLogs}`;
+	}
+
+	_copyToClipboard(text, toastMessage) {
+		AhkDataService.SetClipboard(text);
+		this._showToast(toastMessage);
+	}
+
+	_showToast(message) {
+		this.toast.textContent = message;
+		this.toast.classList.remove('show');
+		void this.toast.offsetWidth; // restart the animation even if a toast is already showing
+		this.toast.classList.add('show');
+	}
+
+	_escape(text) {
+		const div = document.createElement('div');
+		div.textContent = text ?? '';
+		return div.innerHTML;
+	}
+}

--- a/Dashboards/Test Dashboard/User Interface/styles.css
+++ b/Dashboards/Test Dashboard/User Interface/styles.css
@@ -1,0 +1,289 @@
+* {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 0;
+	font-family: Segoe UI, sans-serif;
+	background: #1e1e1e;
+	color: #ddd;
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+}
+
+.title-bar {
+	display: flex;
+	align-items: stretch;
+	height: 32px;
+	background: #2d2d2d;
+	border-bottom: 1px solid #333;
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+.drag-region {
+	flex: 1;
+	display: flex;
+	align-items: center;
+	padding-left: 12px;
+	cursor: default;
+}
+
+.title-text {
+	font-size: 12px;
+	color: #ccc;
+}
+
+.title-btn-container {
+	display: flex;
+}
+
+.title-btn {
+	font-family: Webdings;
+	font-size: 10pt;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	cursor: pointer;
+	color: #ccc;
+}
+
+.title-btn:hover {
+	background: #3d3d3d;
+}
+
+.title-btn-close:hover {
+	background: #e81123;
+	color: #fff;
+}
+
+.toolbar {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 10px;
+	background: #252526;
+	border-bottom: 1px solid #333;
+}
+
+.toolbar button {
+	background: #333;
+	color: #ddd;
+	border: 1px solid #444;
+	border-radius: 4px;
+	padding: 6px 14px;
+	cursor: pointer;
+}
+
+.toolbar button:hover:not(:disabled) {
+	background: #3d3d3d;
+}
+
+.toolbar button:disabled {
+	opacity: 0.6;
+	cursor: default;
+}
+
+#run-count {
+	color: #888;
+	font-size: 12px;
+}
+
+.status-banner {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 10px 16px;
+	background: #7a4a00;
+	color: #ffd699;
+	font-size: 13px;
+	font-weight: 600;
+	animation: banner-pulse 1.6s ease-in-out infinite;
+}
+
+.status-banner[hidden] {
+	display: none;
+}
+
+.spinner {
+	width: 14px;
+	height: 14px;
+	flex-shrink: 0;
+	border-radius: 50%;
+	border: 2px solid rgba(255, 255, 255, 0.35);
+	border-top-color: #fff;
+	animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+	to { transform: rotate(360deg); }
+}
+
+@keyframes banner-pulse {
+	0%, 100% { background: #7a4a00; }
+	50% { background: #a3620a; }
+}
+
+.run-row-pending td {
+	color: #ffb74d;
+	font-style: italic;
+	padding: 10px;
+	white-space: normal;
+}
+
+.run-row-pending .spinner {
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: 4px;
+}
+
+.run-row-pending:hover {
+	background: transparent;
+	cursor: default;
+}
+
+.layout {
+	display: flex;
+	flex: 1;
+	min-height: 0;
+}
+
+#run-table {
+	flex: 1;
+	border-collapse: collapse;
+	overflow-y: auto;
+	display: block;
+	font-size: 13px;
+}
+
+#run-table thead, #run-table tbody {
+	display: table;
+	width: 100%;
+	table-layout: fixed;
+}
+
+#run-table th, #run-table td {
+	text-align: left;
+	padding: 6px 10px;
+	border-bottom: 1px solid #2d2d2d;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+#run-table th {
+	background: #252526;
+	position: sticky;
+	top: 0;
+}
+
+#run-table th:nth-child(1), #run-table td:nth-child(1) { width: 65%; } /* Time */
+#run-table th:nth-child(2), #run-table td:nth-child(2) { width: 35%; } /* Result */
+
+#run-table tbody tr:hover {
+	background: #2a2d2e;
+	cursor: pointer;
+}
+
+#run-table tbody tr.selected {
+	background: #094771;
+}
+
+.result-PASS { color: #89d185; }
+.result-FAIL { color: #f14c4c; }
+.result-TIMEOUT { color: #ff9800; }
+
+#detail-panel {
+	flex: 2;
+	padding: 16px;
+	overflow-y: auto;
+	border-left: 1px solid #333;
+	background: #1e1e1e;
+}
+
+.detail-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 10px;
+}
+
+#detail-panel h2 {
+	font-size: 15px;
+	word-break: break-word;
+}
+
+.copy-btn {
+	flex-shrink: 0;
+	background: #333;
+	color: #ddd;
+	border: 1px solid #444;
+	border-radius: 4px;
+	padding: 4px 8px;
+	cursor: pointer;
+	font-size: 12px;
+}
+
+.copy-btn:hover {
+	background: #3d3d3d;
+}
+
+.suite {
+	margin-top: 16px;
+}
+
+.suite-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+}
+
+.suite-header h3 {
+	font-size: 13px;
+	margin: 0;
+}
+
+#detail-panel pre {
+	white-space: pre-wrap;
+	word-break: break-word;
+	background: #252526;
+	padding: 10px;
+	border-radius: 4px;
+	font-size: 12px;
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.empty-state {
+	color: #888;
+	text-align: center;
+	padding: 20px;
+}
+
+#toast {
+	position: fixed;
+	bottom: 20px;
+	right: 20px;
+	background: #094771;
+	color: #fff;
+	padding: 10px 16px;
+	border-radius: 6px;
+	font-size: 13px;
+	opacity: 0;
+	pointer-events: none;
+	z-index: 1000;
+}
+
+#toast.show {
+	animation: toast-fade 2s ease forwards;
+}
+
+@keyframes toast-fade {
+	0% { opacity: 0; transform: translateY(10px); }
+	10% { opacity: 1; transform: translateY(0); }
+	85% { opacity: 1; transform: translateY(0); }
+	100% { opacity: 0; transform: translateY(10px); }
+}

--- a/Startup/Startup Menu Tray.ahk
+++ b/Startup/Startup Menu Tray.ahk
@@ -28,6 +28,7 @@ class StartupMenuTray {
         A_TrayMenu.Add("Reload", (*) => System.KillAndReload())
         this._AddProfilesToTrayMenu()
         A_TrayMenu.Add("Log Dashboard", (*) => ShowLogDashboard())
+        A_TrayMenu.Add("Test Dashboard", (*) => RunTests())
         A_TrayMenu.Add("Exit", (*) => System.KillAllAHkProcesses())
     }
 

--- a/Startup/Startup.ahk
+++ b/Startup/Startup.ahk
@@ -12,6 +12,7 @@
 ;   - Switch profiles using tray menu
 ; ============================================================================
 #Include ..\Dashboards\Logger\Logging.ahk
+#Include ..\Dashboards\Test Dashboard\Test Dashboard.ahk
 #Include ..\Lib\Core\Paths.ahk
 #Include ..\Profiles\Profile Manager.ahk
 #Include ..\Secrets\Secrets File Manager.ahk

--- a/Tests/Invoke-AllTests.ps1
+++ b/Tests/Invoke-AllTests.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+    Runs the syntax check, unit tests, and integration tests in one pass and
+    logs a structured result for the Test Dashboard to display.
+
+.DESCRIPTION
+    Each suite script (Invoke-SyntaxCheck.ps1, Invoke-UnitTests.ps1,
+    Invoke-IntegrationTests.ps1) calls `exit` directly, so each one is launched
+    as its own child process rather than dot-sourced or called in-process.
+
+    Writes Logs\test-run-status.json (current run state, polled by the Test
+    Dashboard while a run is in progress) and appends one JSON line per run to
+    Logs\test-run-history.log (newest run last, same line-delimited-JSON
+    convention as Logs\errors.log). Both files live under Logs\, which is
+    already git-ignored.
+#>
+
+param(
+    [int]$TimeoutSeconds = 180
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$logsDir = Join-Path $repoRoot "Logs"
+if (-not (Test-Path $logsDir)) {
+    New-Item -ItemType Directory -Path $logsDir | Out-Null
+}
+
+$statusPath = Join-Path $logsDir "test-run-status.json"
+$historyPath = Join-Path $logsDir "test-run-history.log"
+
+function Write-Status {
+    param([string]$Status, [hashtable]$Extra = @{})
+    $obj = @{ status = $Status; updatedAt = (Get-Date).ToString("o") }
+    foreach ($key in $Extra.Keys) { $obj[$key] = $Extra[$key] }
+    ($obj | ConvertTo-Json -Compress) | Set-Content -Path $statusPath -Encoding UTF8
+}
+
+Write-Status "running"
+
+$suites = @(
+    @{ name = "Syntax Check"; script = Join-Path $PSScriptRoot "Invoke-SyntaxCheck.ps1" }
+    @{ name = "Unit Tests"; script = Join-Path $PSScriptRoot "Invoke-UnitTests.ps1" }
+    @{ name = "Integration Tests"; script = Join-Path $PSScriptRoot "Invoke-IntegrationTests.ps1" }
+)
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ahk-all-tests-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+$results = @()
+try {
+    foreach ($suite in $suites) {
+        $stdoutPath = Join-Path $tempDir ((New-Guid).Guid + ".stdout.txt")
+        $stderrPath = Join-Path $tempDir ((New-Guid).Guid + ".stderr.txt")
+
+        $proc = Start-Process -FilePath "powershell.exe" `
+            -ArgumentList @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "`"$($suite.script)`"") `
+            -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath `
+            -WindowStyle Hidden -PassThru
+
+        # Touching .Handle forces PowerShell to open the process with the access
+        # rights needed to read .ExitCode later (same fix as Tests/Support/AhkRunner.psm1).
+        $null = $proc.Handle
+        $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
+
+        if (-not $exited) {
+            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            $results += @{ name = $suite.name; status = "TIMEOUT"; exitCode = $null; output = "Timed out after ${TimeoutSeconds}s." }
+            continue
+        }
+
+        $stdout = if (Test-Path $stdoutPath) { (Get-Content -Raw $stdoutPath) } else { "" }
+        $stderr = if (Test-Path $stderrPath) { (Get-Content -Raw $stderrPath) } else { "" }
+        $output = ("$stdout`n$stderr").Trim()
+
+        $status = if ($proc.ExitCode -eq 0) { "PASS" } else { "FAIL" }
+        $results += @{ name = $suite.name; status = $status; exitCode = $proc.ExitCode; output = $output }
+    }
+} finally {
+    Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+}
+
+$overall = if (@($results | Where-Object { $_.status -ne "PASS" }).Count -gt 0) { "FAIL" } else { "PASS" }
+$run = @{
+    timestamp     = (Get-Date).ToString("o")
+    overallStatus = $overall
+    suites        = $results
+}
+
+($run | ConvertTo-Json -Depth 5 -Compress) | Add-Content -Path $historyPath -Encoding UTF8
+Write-Status "idle" @{ lastRunAt = $run.timestamp; lastRunStatus = $overall }
+
+if ($overall -eq "PASS") {
+    Write-Host "All test suites passed."
+    exit 0
+} else {
+    Write-Host "One or more test suites failed."
+    exit 1
+}

--- a/Tests/Invoke-SyntaxCheck.ps1
+++ b/Tests/Invoke-SyntaxCheck.ps1
@@ -47,6 +47,8 @@ $targets.Add($startupFile)
 $targets.Add((Join-Path $repoRoot "Dashboards\Logger\Logger Host.ahk"))
 $targets.Add((Join-Path $repoRoot "Dashboards\Log Dashboard\Dashboard.ahk"))
 $targets.Add((Join-Path $repoRoot "Dashboards\Logger\Logging.ahk"))
+$targets.Add((Join-Path $repoRoot "Dashboards\Test Dashboard\Dashboard.ahk"))
+$targets.Add((Join-Path $repoRoot "Tests\Run-Tests.ahk"))
 
 $runCalls = [regex]::Matches($startupContent, 'Run\(Paths\.(\w+)\s*"([^"]+)"\)')
 foreach ($m in $runCalls) {

--- a/Tests/Run-Tests.ahk
+++ b/Tests/Run-Tests.ahk
@@ -1,0 +1,18 @@
+; ============================================================================
+; Run-Tests - Manually kicks off the full test suite and opens the dashboard
+; ============================================================================
+;
+; Runs the syntax check, unit tests, and integration tests in the background
+; (Tests\Invoke-AllTests.ps1) and opens the Test Dashboard so you can watch
+; progress and review pass/fail results as they land. Double-click this file,
+; or run it with AutoHotkey64.exe, whenever you want a manual test run.
+; ============================================================================
+
+#Requires AutoHotkey v2
+#SingleInstance Force
+
+#Include ..\Dashboards\Test Dashboard\Test Dashboard.ahk
+
+ShowTestDashboard()
+Run('powershell.exe -NoProfile -ExecutionPolicy Bypass -File "' TestDashboard.RUNNER_SCRIPT '"', , "Hide")
+ExitApp()

--- a/Tests/Support/AhkRunner.psm1
+++ b/Tests/Support/AhkRunner.psm1
@@ -5,14 +5,29 @@
 #>
 
 function Get-AhkExecutable {
-    # AutoHotkey.exe (v2) must already be on PATH - see the setup step in
-    # .github/workflows/ahk-tests.yml for how CI installs it.
+    # Prefer PATH (this is how CI installs it - see the setup step in
+    # .github/workflows/ahk-tests.yml) but a local install rarely adds itself
+    # to PATH, so fall back to the default v2 install locations before giving up.
     $ahkExe = Get-Command "AutoHotkey.exe" -ErrorAction SilentlyContinue
     if (-not $ahkExe) {
         $ahkExe = Get-Command "AutoHotkey64.exe" -ErrorAction SilentlyContinue
     }
     if (-not $ahkExe) {
-        throw "Could not find AutoHotkey.exe or AutoHotkey64.exe on PATH."
+        $candidates = @(
+            (Join-Path $env:ProgramFiles "AutoHotkey\v2\AutoHotkey64.exe")
+            (Join-Path $env:ProgramFiles "AutoHotkey\v2\AutoHotkey.exe")
+            (Join-Path ${env:ProgramFiles(x86)} "AutoHotkey\v2\AutoHotkey64.exe")
+            (Join-Path ${env:ProgramFiles(x86)} "AutoHotkey\v2\AutoHotkey.exe")
+        )
+        foreach ($candidate in $candidates) {
+            if ($candidate -and (Test-Path $candidate)) {
+                $ahkExe = [pscustomobject]@{ Source = $candidate }
+                break
+            }
+        }
+    }
+    if (-not $ahkExe) {
+        throw "Could not find AutoHotkey.exe or AutoHotkey64.exe on PATH or in the default AutoHotkey v2 install location."
     }
     return $ahkExe
 }


### PR DESCRIPTION
## Summary
- Adds `Tests/Invoke-AllTests.ps1`, which runs the syntax check, unit tests, and integration tests in one pass and logs structured pass/fail results to `Logs/` (git-ignored).
- Adds a WebView2 **Test Dashboard** (`Dashboards/Test Dashboard/`) showing this session's run history, per-suite output, copy-to-clipboard, a prominent "running" banner + placeholder row while a run is in progress, and auto-selecting the newest run when it finishes. History is cleared each time the dashboard process starts, so it never shows stale runs from a previous session.
- Reachable three ways: the tray menu, the `Test` command-bar entry (Age of Efficiency), or running `Tests/Run-Tests.ahk` directly.
- `Tests/Support/AhkRunner.psm1`'s `Get-AhkExecutable` now falls back to the default AutoHotkey v2 install path when it isn't on `PATH`, so the dashboard's "Run All Tests" works even without a PATH entry.

## Test plan
- [x] Ran the real syntax check, unit tests, and integration tests directly — all pass.
- [x] Ran `Invoke-AllTests.ps1` for real; verified `Logs/test-run-status.json` and `Logs/test-run-history.log` are written correctly.
- [x] Launched the actual Test Dashboard window and drove it with real clicks: run selection, PASS/FAIL styling, suite detail view, copy-to-clipboard (verified via clipboard read).
- [x] Verified the running-state banner, placeholder row, and auto-select-on-finish behavior live, including catching and fixing a `[hidden]` CSS-specificity bug found during that test.
- [x] Verified session-scoped history clearing (seeded a stale run, confirmed it disappears on dashboard restart).
- [x] Verified `Get-AhkExecutable`'s PATH fallback with PATH stripped down to nothing but `System32`/`Windows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)