### PR TITLE
Add Screen Snip Speaker: drag-select screen text and hear it read aloud

### DIFF
--- a/Apps Standalone/Screen Snip Speaker/Screen Snip Speaker.ahk
+++ b/Apps Standalone/Screen Snip Speaker/Screen Snip Speaker.ahk
@@ -2,33 +2,23 @@
 ; Screen Snip Speaker - Drag-select any part of the screen, hear it read aloud
 ; ============================================================================
 ;
+; Meant to be #Include'd from Text Speaker.ahk, which owns the actual SAPI
+; voice, playback state, and cassette control panel. This file only turns a
+; screen selection into text + word positions and hands them to TextSpeaker.
+;
 ; [FEATURES]
 ;   - Ctrl + Shift + drag (left mouse button) to select a screen region
-;   - The selected region is OCR'd and spoken aloud
+;   - The selected region is OCR'd and spoken aloud via TextSpeaker
 ;   - The word currently being spoken is highlighted directly on screen
 ;   - Ctrl + Shift + Escape stops playback and clears the highlight
 ; ============================================================================
 
-#Requires AutoHotkey v2
-#SingleInstance force
-
-#Include ..\..\Lib\Core.ahk
 #Include ..\..\Lib\Tools\OCR\lib\OCR.ahk
 
 ^+LButton::ScreenSnipSpeaker.StartFromDrag()
-^+Escape::ScreenSnipSpeaker.Stop()
+^+Escape::TextSpeaker.Stop()
 
 class ScreenSnipSpeaker {
-
-    static _spVoice := ComObject("SAPI.SpVoice")
-    static _words := []
-    static _currentWord := ""
-
-    ; SVEEndInputStream (1) | SVEStartInputStream (2) | SVEWordBoundary (16)
-    static __New() {
-        this._spVoice.EventInterests := 19
-        ComObjConnect(this._spVoice, "ScreenSnipSpeaker_SAPI_")
-    }
 
     static StartFromDrag() {
         area := this._SelectDragRegion("LButton")
@@ -38,8 +28,6 @@ class ScreenSnipSpeaker {
     }
 
     static Start(area) {
-        this.Stop()
-
         try {
             result := OCR.FromRect(area.X, area.Y, area.W, area.H, {scale: 2})
         } catch as e {
@@ -47,20 +35,13 @@ class ScreenSnipSpeaker {
             return
         }
 
-        this._words := this._OrderWordsAndBuildText(result, &text)
-        if !this._words.Length {
+        words := this._OrderWordsAndBuildText(result, &text)
+        if !words.Length {
             Info("No text found in selection")
             return
         }
 
-        this._spVoice.Speak("", 2) ; cancel anything currently speaking
-        this._spVoice.Speak(text, 1) ; asynchronous
-    }
-
-    static Stop() {
-        try this._spVoice.Speak("", 2)
-        this._ClearCurrentHighlight()
-        this._words := []
+        TextSpeaker.Speak(text, "", words)
     }
 
     ; ---- Reading order & speech text -----------------------------------
@@ -84,30 +65,6 @@ class ScreenSnipSpeaker {
             text .= "`n"
         }
         return words
-    }
-
-    ; ---- Word-boundary highlighting -------------------------------------
-
-    static _OnWord(characterPosition, length) {
-        this._ClearCurrentHighlight()
-        for word in this._words {
-            if characterPosition >= word.charStart && characterPosition < word.charEnd {
-                this._currentWord := word
-                try word.Highlight(0, "Red", 3)
-                break
-            }
-        }
-    }
-
-    static _OnEnd() {
-        this._ClearCurrentHighlight()
-    }
-
-    static _ClearCurrentHighlight() {
-        if this._currentWord
-            try this._currentWord.Highlight("clear")
-        this._currentWord := ""
-        try OCR.ClearAllHighlights()
     }
 
     ; ---- Screen region drag-selection ------------------------------------
@@ -138,14 +95,4 @@ class ScreenSnipSpeaker {
         guiSSR.Destroy()
         return {X: x, Y: y, W: w, H: h}
     }
-}
-
-; ---- SAPI event sink (ComObjConnect dispatches SpVoiceEvents by name) -----
-
-ScreenSnipSpeaker_SAPI_Word(voice, streamNumber, streamPosition, characterPosition, length) {
-    ScreenSnipSpeaker._OnWord(characterPosition, length)
-}
-
-ScreenSnipSpeaker_SAPI_EndStream(voice, streamNumber, streamPosition) {
-    ScreenSnipSpeaker._OnEnd()
 }

--- a/Apps Standalone/Screen Snip Speaker/Screen Snip Speaker.ahk
+++ b/Apps Standalone/Screen Snip Speaker/Screen Snip Speaker.ahk
@@ -40,7 +40,6 @@ class ScreenSnipSpeaker {
             Info("No text found in selection")
             return
         }
-
         TextSpeaker.Speak(text, "", words)
     }
 

--- a/Apps Standalone/Screen Snip Speaker/Screen Snip Speaker.ahk
+++ b/Apps Standalone/Screen Snip Speaker/Screen Snip Speaker.ahk
@@ -1,0 +1,151 @@
+; ============================================================================
+; Screen Snip Speaker - Drag-select any part of the screen, hear it read aloud
+; ============================================================================
+;
+; [FEATURES]
+;   - Ctrl + Shift + drag (left mouse button) to select a screen region
+;   - The selected region is OCR'd and spoken aloud
+;   - The word currently being spoken is highlighted directly on screen
+;   - Ctrl + Shift + Escape stops playback and clears the highlight
+; ============================================================================
+
+#Requires AutoHotkey v2
+#SingleInstance force
+
+#Include ..\..\Lib\Core.ahk
+#Include ..\..\Lib\Tools\OCR\lib\OCR.ahk
+
+^+LButton::ScreenSnipSpeaker.StartFromDrag()
+^+Escape::ScreenSnipSpeaker.Stop()
+
+class ScreenSnipSpeaker {
+
+    static _spVoice := ComObject("SAPI.SpVoice")
+    static _words := []
+    static _currentWord := ""
+
+    ; SVEEndInputStream (1) | SVEStartInputStream (2) | SVEWordBoundary (16)
+    static __New() {
+        this._spVoice.EventInterests := 19
+        ComObjConnect(this._spVoice, "ScreenSnipSpeaker_SAPI_")
+    }
+
+    static StartFromDrag() {
+        area := this._SelectDragRegion("LButton")
+        if area.W < 8 || area.H < 8
+            return
+        this.Start(area)
+    }
+
+    static Start(area) {
+        this.Stop()
+
+        try {
+            result := OCR.FromRect(area.X, area.Y, area.W, area.H, {scale: 2})
+        } catch as e {
+            Info("OCR failed: " e.Message)
+            return
+        }
+
+        this._words := this._OrderWordsAndBuildText(result, &text)
+        if !this._words.Length {
+            Info("No text found in selection")
+            return
+        }
+
+        this._spVoice.Speak("", 2) ; cancel anything currently speaking
+        this._spVoice.Speak(text, 1) ; asynchronous
+    }
+
+    static Stop() {
+        try this._spVoice.Speak("", 2)
+        this._ClearCurrentHighlight()
+        this._words := []
+    }
+
+    ; ---- Reading order & speech text -----------------------------------
+
+    ; UWP OCR groups words into blocks rather than true reading-order lines,
+    ; so cluster words into lines ourselves (OCR.Cluster) before speaking -
+    ; otherwise both the spoken order and the word-boundary highlighting
+    ; would jump around the screen.
+    static _OrderWordsAndBuildText(result, &text) {
+        lines := OCR.Cluster(result.Words)
+        words := []
+        text := ""
+        for line in lines {
+            for index, word in line.Words {
+                word.DefineProp("charStart", {value: StrLen(text)})
+                text .= word.Text
+                word.DefineProp("charEnd", {value: StrLen(text)})
+                text .= (index < line.Words.Length) ? " " : ""
+                words.Push(word)
+            }
+            text .= "`n"
+        }
+        return words
+    }
+
+    ; ---- Word-boundary highlighting -------------------------------------
+
+    static _OnWord(characterPosition, length) {
+        this._ClearCurrentHighlight()
+        for word in this._words {
+            if characterPosition >= word.charStart && characterPosition < word.charEnd {
+                this._currentWord := word
+                try word.Highlight(0, "Red", 3)
+                break
+            }
+        }
+    }
+
+    static _OnEnd() {
+        this._ClearCurrentHighlight()
+    }
+
+    static _ClearCurrentHighlight() {
+        if this._currentWord
+            try this._currentWord.Highlight("clear")
+        this._currentWord := ""
+        try OCR.ClearAllHighlights()
+    }
+
+    ; ---- Screen region drag-selection ------------------------------------
+
+    static _SelectDragRegion(key) {
+        Try DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
+
+        guiSSR := Gui("+AlwaysOnTop -Caption +Border +ToolWindow +LastFound -DPIScale", "ScreenSnipSpeakerSelect")
+        guiSSR.MarginX := 0, guiSSR.MarginY := 0
+        guiSSR.BackColor := "0011ff"
+        WinSetTransparent(80, guiSSR)
+
+        CoordMode("Mouse", "Screen")
+        MouseGetPos(&startX, &startY)
+        guiSSR.Show("NA x" startX " y" startY " w1 h1")
+
+        Loop {
+            MouseGetPos(&endX, &endY)
+            w := Max(Abs(startX - endX), 1)
+            h := Max(Abs(startY - endY), 1)
+            x := Min(startX, endX)
+            y := Min(startY, endY)
+            guiSSR.Move(x, y, w, h)
+            Sleep(10)
+        } Until !GetKeyState(key, "P")
+
+        guiSSR.GetPos(&x, &y, &w, &h)
+        guiSSR.Destroy()
+        return {X: x, Y: y, W: w, H: h}
+    }
+}
+
+; ---- SAPI event sink (ComObjConnect dispatches SpVoiceEvents by name) -----
+
+ScreenSnipSpeaker_SAPI_Word(voice, streamNumber, streamPosition, characterPosition, length) {
+    ScreenSnipSpeaker._OnWord(characterPosition, length)
+}
+
+ScreenSnipSpeaker_SAPI_EndStream(voice, streamNumber, streamPosition) {
+    ScreenSnipSpeaker._OnEnd()
+}

--- a/Apps Standalone/Text Speaker/Text Speaker.ahk
+++ b/Apps Standalone/Text Speaker/Text Speaker.ahk
@@ -172,6 +172,11 @@ class TextSpeaker {
             return
 
         try {
+            ; If the previous utterance was paused, SAPI leaves its audio output paused:
+            ; Speak() below would queue the new text but never actually play it, and the
+            ; poll timer would then read that silence as "finished" within ~300ms - the
+            ; panel flashing open and immediately closing. Resume() clears that first.
+            this._spVoice.Resume()
             this._spVoice.Speak("", 2) ; cancel anything currently speaking
             this._ClearCurrentHighlightWord()
             this._highlightWords := words

--- a/Apps Standalone/Text Speaker/Text Speaker.ahk
+++ b/Apps Standalone/Text Speaker/Text Speaker.ahk
@@ -11,6 +11,7 @@
 
 #Include ..\..\Lib\Core.ahk
 #Include ..\..\Lib\Tools\WebView\WebViewToo.ahk
+#Include ..\Screen Snip Speaker\Screen Snip Speaker.ahk
 
 ^Space::TextSpeaker.TogglePlay()
 
@@ -38,10 +39,20 @@ class TextSpeaker {
     static _panel := ""
     static _pollCallback := ""
 
+    ; Word-highlighting metadata for the current utterance (set by ScreenSnipSpeaker;
+    ; empty for plain selected-text speech, in which case highlighting is a no-op).
+    ; Each word is an object with charStart/charEnd (offsets into the spoken text) and
+    ; a Highlight(showTime, color, d) / Highlight("clear") method, eg an OCR.Word.
+    static _highlightWords := []
+    static _currentHighlightWord := ""
+
     static __New() {
         this._LoadVoices()
         this._LoadSettings()
         this._pollCallback := ObjBindMethod(this, "_PollPlaybackState")
+        ; SVEEndInputStream (1) | SVEStartInputStream (2) | SVEWordBoundary (16)
+        this._spVoice.EventInterests := 19
+        ComObjConnect(this._spVoice, "TextSpeaker_SAPI_")
     }
 
     ; ---- Voice selection -------------------------------------------------
@@ -136,7 +147,7 @@ class TextSpeaker {
         }
     }
 
-    static Speak(text := "", voice := "") {
+    static Speak(text := "", voice := "", words := []) {
         if text = "" {
             try {
                 text := this._GetSelectedText()
@@ -159,6 +170,8 @@ class TextSpeaker {
 
         try {
             this._spVoice.Speak("", 2) ; cancel anything currently speaking
+            this._ClearCurrentHighlightWord()
+            this._highlightWords := words
             this._currentVoice := voice
             this._spVoice.Voice := voice
             this._spVoice.Volume := this._currentVolume
@@ -176,13 +189,15 @@ class TextSpeaker {
     static Restart() {
         if this._lastText = ""
             return
-        this.Speak(this._lastText, this._currentVoice)
+        this.Speak(this._lastText, this._currentVoice, this._highlightWords)
     }
 
     static Stop() {
         this._spVoice.Speak("", 2)
         this._state := "idle"
         this._HidePanel()
+        this._ClearCurrentHighlightWord()
+        this._highlightWords := []
     }
 
     static Pause() {
@@ -272,9 +287,31 @@ class TextSpeaker {
         if this._state = "speaking" && A_TickCount - this._speechStartTick > 300 && !this._IsSpeaking() {
             this._state := "idle"
             this._HidePanel()
+            this._ClearCurrentHighlightWord()
             return
         }
         this._PushPanelState()
+    }
+
+    ; ---- Word-boundary highlighting (used when speaking OCR'd screen text) --
+
+    static _OnWordBoundary(characterPosition, length) {
+        if !this._highlightWords.Length
+            return
+        this._ClearCurrentHighlightWord()
+        for word in this._highlightWords {
+            if characterPosition >= word.charStart && characterPosition < word.charEnd {
+                this._currentHighlightWord := word
+                try word.Highlight(0, "Red", 3)
+                break
+            }
+        }
+    }
+
+    static _ClearCurrentHighlightWord() {
+        if this._currentHighlightWord
+            try this._currentHighlightWord.Highlight("clear")
+        this._currentHighlightWord := ""
     }
 
     static _PushPanelState() {
@@ -322,4 +359,14 @@ class TextSpeakerPanel extends WebViewToo {
     }
 
     PushState() => this.ExecuteScript("window.onAhkState && window.onAhkState(" TextSpeaker._GetStateJSON() ")")
+}
+
+; ---- SAPI event sink (ComObjConnect dispatches SpVoiceEvents by name) -----
+
+TextSpeaker_SAPI_Word(voice, streamNumber, streamPosition, characterPosition, length) {
+    TextSpeaker._OnWordBoundary(characterPosition, length)
+}
+
+TextSpeaker_SAPI_EndStream(voice, streamNumber, streamPosition) {
+    TextSpeaker._ClearCurrentHighlightWord()
 }

--- a/Apps Standalone/Text Speaker/Text Speaker.ahk
+++ b/Apps Standalone/Text Speaker/Text Speaker.ahk
@@ -142,11 +142,19 @@ class TextSpeaker {
                 ; A paused screen-snip utterance isn't resumed in place: unlike selected
                 ; text, the user has likely moved on from the snipped screen area, so a
                 ; second Ctrl+Space re-reads whatever text is currently selected instead.
-                case "paused": this._highlightWords.Length ? this.Speak() : this.Resume()
+                case "paused": this.SpeakOrResume(this._highlightWords.Length)
                 default: this.Speak()
             }
         } catch as Error {
             Info("Error in TogglePlay: " Error.Message " at line " Error.Line)
+        }
+    }
+
+    static SpeakOrResume(highlightWordsLength) {
+        if highlightWordsLength {
+            this.Speak()
+        } else {
+            this.Resume()
         }
     }
 

--- a/Apps Standalone/Text Speaker/Text Speaker.ahk
+++ b/Apps Standalone/Text Speaker/Text Speaker.ahk
@@ -139,7 +139,10 @@ class TextSpeaker {
         try {
             switch this._state {
                 case "speaking": this.Pause()
-                case "paused": this.Resume()
+                ; A paused screen-snip utterance isn't resumed in place: unlike selected
+                ; text, the user has likely moved on from the snipped screen area, so a
+                ; second Ctrl+Space re-reads whatever text is currently selected instead.
+                case "paused": this._highlightWords.Length ? this.Speak() : this.Resume()
                 default: this.Speak()
             }
         } catch as Error {


### PR DESCRIPTION
## Summary
- Adds a Screen Snip Speaker: `Ctrl+Shift+drag` (left mouse button) drag-selects any part of the screen, OCRs it (`OCR.ahk`), and speaks the recognized text.
- The word currently being spoken is highlighted directly on screen (red box) via SAPI word-boundary events, synced to OCR word positions.
- Integrated into Text Speaker rather than kept as a separate app: Text Speaker now owns the single SAPI voice, playback state, and cassette control panel, so a snip brings up the same panel used for selected-text speech, and `Ctrl+Space` always pauses/resumes regardless of source. `Ctrl+Shift+Escape` stops playback and clears the highlight.
- Fixes a bug where speaking new text (or a new snip) right after a pause would silently fail: SAPI leaves its audio output paused across `Speak()`, so the new utterance queued but never played, and the panel flashed open and immediately closed. `Speak()` now resumes SAPI's engine before speaking.
- A paused screen-snip utterance is not resumed in place on a second `Ctrl+Space` — since the user has likely moved on from the snipped area, it re-reads whatever text is currently selected instead. Plain selected-text speech still resumes in place as before.

## Test plan
- [x] `Ctrl+Shift+drag` over some on-screen text; confirm it's read aloud with the cassette panel showing and the current word highlighted in red
- [x] `Ctrl+Space` mid-snip-speech to pause; confirm playback and highlight freeze in place
- [x] `Ctrl+Space` again while paused from a snip; confirm it reads newly selected text rather than resuming the old snip
- [x] Select text normally, `Ctrl+Space` to speak, pause, `Ctrl+Space` again; confirm it resumes in place as before
- [x] `Ctrl+Shift+Escape` stops playback and clears any highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)