### PR TITLE
Implement daily ticket-implementation agent

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -38,3 +38,11 @@
 - name: "risk: destructive"
   color: "#B60205"
   description: Requires human execution, not agent-eligible.
+
+- name: "agent-in-progress"
+  color: "#FEF2C0"
+  description: An automated agent has claimed this issue and is working on it.
+
+- name: "agent-authored"
+  color: "#1D76DB"
+  description: This PR was opened by an automated agent, not a human.

--- a/.github/scripts/Select-AgentIssue.ps1
+++ b/.github/scripts/Select-AgentIssue.ps1
@@ -1,0 +1,71 @@
+<#
+Picks one issue for the daily ticket agent (.github/workflows/daily-agent.yml)
+to implement. See agent-plan.md section 3 for the selection rules this
+implements. Read-only - makes no changes to issues or the board.
+
+Outputs (via $env:GITHUB_OUTPUT): issue_number, issue_title, branch_prefix.
+When no eligible issue exists, issue_number is left empty and the caller
+should treat that as "nothing to do".
+#>
+param(
+    [Parameter(Mandatory)] [string]$Repo   # e.g. "Flop0333/AutoHotkey"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-CandidateIssues($riskLabel) {
+    $lines = gh issue list --repo $Repo --state open `
+        --label "agent-ready" --label $riskLabel `
+        --json number,title,createdAt,labels --limit 100
+    if ($LASTEXITCODE -ne 0) { throw "gh issue list failed for label '$riskLabel'" }
+    # PowerShell captures native stdout as a string array (one element per
+    # line); ConvertFrom-Json needs it rejoined into one string first, or
+    # pretty-printed/multi-line JSON parses into garbage silently.
+    ($lines -join "`n") | ConvertFrom-Json
+}
+
+$combined = @(Get-CandidateIssues "risk: read") + @(Get-CandidateIssues "risk: reversible")
+# An issue should only ever carry one risk label, so this union shouldn't
+# have overlaps - but dedupe defensively by number. Deliberately not
+# `Sort-Object number -Unique`: it drops legitimate entries on this data
+# shape (single-object vs. array results from ConvertFrom-Json), verified
+# by hand while testing this script.
+$seenNumbers = @{}
+$candidates = foreach ($c in $combined) {
+    if (-not $seenNumbers.ContainsKey($c.number)) {
+        $seenNumbers[$c.number] = $true
+        $c
+    }
+}
+
+$eligible = $candidates | Where-Object {
+    $labelNames = $_.labels | ForEach-Object { $_.name }
+    $size = $labelNames | Where-Object { $_ -in @("size: S", "size: M") }
+    $inProgress = $labelNames -contains "agent-in-progress"
+    # size: L is never auto-picked (agent-plan.md #9); agent-in-progress means
+    # a previous run already claimed it and hasn't failed/finished.
+    $size -and -not $inProgress
+}
+
+# Smallest first (S before M), then oldest first within the same size.
+$sizeRank = @{ "size: S" = 0; "size: M" = 1 }
+$picked = $eligible | Sort-Object `
+    @{ Expression = { $sizeRank[($_.labels | ForEach-Object { $_.name } | Where-Object { $_ -in @("size: S", "size: M") } | Select-Object -First 1)] } }, `
+    @{ Expression = { [datetime]$_.createdAt } } `
+    | Select-Object -First 1
+
+if (-not $picked) {
+    Write-Host "No eligible agent-ready issue found (size S/M, risk read/reversible, not already in progress)."
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "issue_number="
+    exit 0
+}
+
+# A stable, predictable prefix for the branch the agent will create - not
+# the full branch name (the agent/action picks the rest). Also used to find
+# the resulting PR afterwards.
+$branchPrefix = "agent/issue-$($picked.number)-"
+
+Write-Host "Selected #$($picked.number): $($picked.title)"
+Add-Content -Path $env:GITHUB_OUTPUT -Value "issue_number=$($picked.number)"
+Add-Content -Path $env:GITHUB_OUTPUT -Value "issue_title=$($picked.title)"
+Add-Content -Path $env:GITHUB_OUTPUT -Value "branch_prefix=$branchPrefix"

--- a/.github/scripts/Set-BoardStatus.ps1
+++ b/.github/scripts/Set-BoardStatus.ps1
@@ -1,0 +1,91 @@
+<#
+Moves an issue's Project (v2) board item to a given Status column
+("Todo" / "In Progress" / "Done"). Used by daily-agent.yml, and reusable by
+any future workflow that needs to move a card (e.g. #49's board/issue sync).
+
+Requires a token with Projects read/write access in $env:GH_TOKEN - the
+default GITHUB_TOKEN cannot write to Projects v2 (same limitation noted in
+add-to-project.yml), so callers should pass the ADD_TO_PROJECT_PAT secret.
+
+Silently does nothing if the issue has no matching board item, so it's safe
+to call for an issue that isn't (yet) on the board.
+#>
+param(
+    [Parameter(Mandatory)] [string]$ProjectUrl,   # e.g. https://github.com/users/Flop0333/projects/8
+    [Parameter(Mandatory)] [int]$IssueNumber,
+    [Parameter(Mandatory)] [ValidateSet("Todo", "In Progress", "Done")] [string]$Status
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($ProjectUrl -notmatch '^https://github\.com/(users|orgs)/([^/]+)/projects/(\d+)/?$') {
+    throw "PROJECT_URL '$ProjectUrl' doesn't look like a Project (v2) URL (expected https://github.com/users|orgs/<owner>/projects/<number>)."
+}
+$ownerType = $Matches[1]   # "users" or "orgs"
+$owner = $Matches[2]
+$projectNumber = [int]$Matches[3]
+$ownerField = if ($ownerType -eq "users") { "user" } else { "organization" }
+
+function Invoke-GraphQL($query, [hashtable]$vars) {
+    # Passed via a temp file, not inline -f query="...", because PowerShell's
+    # argument marshalling to the native gh.exe mangles embedded double
+    # quotes (e.g. `name: "Status"`), producing invalid GraphQL.
+    $queryFile = New-TemporaryFile
+    Set-Content -Path $queryFile -Value $query -NoNewline
+    try {
+        # -F (not -f) is required here: only -F/--field does the "@file reads
+        # the value from a file" substitution that -f/--raw-field lacks.
+        $args = @("api", "graphql", "-F", "query=@$queryFile")
+        foreach ($key in $vars.Keys) {
+            $isInt = $vars[$key] -is [int]
+            $flag = if ($isInt) { "-F" } else { "-f" }
+            $args += $flag
+            $args += "$key=$($vars[$key])"
+        }
+        $out = gh @args
+        if ($LASTEXITCODE -ne 0) { throw "gh api graphql failed: $out" }
+        $out | ConvertFrom-Json
+    } finally {
+        Remove-Item $queryFile -ErrorAction SilentlyContinue
+    }
+}
+
+$projectQuery = @"
+query(`$owner: String!, `$number: Int!) {
+  $ownerField(login: `$owner) {
+    projectV2(number: `$number) {
+      id
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField { id options { id name } }
+      }
+      items(first: 100) {
+        nodes { id content { ... on Issue { number } } }
+      }
+    }
+  }
+}
+"@
+$result = Invoke-GraphQL $projectQuery @{ owner = $owner; number = $projectNumber }
+$project = $result.data.$ownerField.projectV2
+if (-not $project) { throw "Could not find project $projectNumber for $ownerType/$owner - check PROJECT_URL." }
+
+$item = $project.items.nodes | Where-Object { $_.content.number -eq $IssueNumber } | Select-Object -First 1
+if (-not $item) {
+    Write-Host "Issue #$IssueNumber has no board item yet (maybe add-to-project.yml hasn't run for it) - skipping."
+    exit 0
+}
+
+$option = $project.field.options | Where-Object { $_.name -eq $Status } | Select-Object -First 1
+if (-not $option) { throw "Board has no '$Status' option on its Status field." }
+
+$mutation = @"
+mutation(`$project: ID!, `$item: ID!, `$field: ID!, `$option: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: `$project, itemId: `$item, fieldId: `$field,
+    value: { singleSelectOptionId: `$option }
+  }) { projectV2Item { id } }
+}
+"@
+Invoke-GraphQL $mutation @{ project = $project.id; item = $item.id; field = $project.field.id; option = $option.id } | Out-Null
+
+Write-Host "Moved issue #$IssueNumber to '$Status' on the board."

--- a/.github/workflows/daily-agent.yml
+++ b/.github/workflows/daily-agent.yml
@@ -1,0 +1,133 @@
+name: Daily ticket agent
+
+# Design: agent-plan.md (proposal reviewed and approved on issue #47 before
+# this was written).
+#
+# Requires one new one-time setup step, otherwise the "Run Claude Code" step
+# below will fail loudly rather than silently doing nothing:
+#   - Create a repo secret ANTHROPIC_API_KEY with an Anthropic API key that
+#     has Claude Code access (Settings > Secrets and variables > Actions).
+# Reuses the ADD_TO_PROJECT_PAT secret and PROJECT_URL variable that
+# add-to-project.yml already requires - no separate board setup needed.
+#
+# NOTE FOR THE MAINTAINER: this is new automation that opens PRs
+# unattended. Before relying on the daily schedule, trigger it once by hand
+# (Actions tab -> Daily ticket agent -> Run workflow) against a real
+# agent-ready/size:S/risk:read-or-reversible issue and check the result.
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # daily 08:00 UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: daily-ticket-agent
+  cancel-in-progress: false
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      issue_number: ${{ steps.select.outputs.issue_number }}
+      issue_title: ${{ steps.select.outputs.issue_title }}
+      branch_prefix: ${{ steps.select.outputs.branch_prefix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: select
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./.github/scripts/Select-AgentIssue.ps1 -Repo "${{ github.repository }}"
+
+  implement:
+    needs: select
+    if: needs.select.outputs.issue_number != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Claim issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue edit ${{ needs.select.outputs.issue_number }} --add-label agent-in-progress --repo ${{ github.repository }}
+
+      - name: Move board item to In Progress
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          ./.github/scripts/Set-BoardStatus.ps1 `
+            -ProjectUrl "${{ vars.PROJECT_URL }}" `
+            -IssueNumber ${{ needs.select.outputs.issue_number }} `
+            -Status "In Progress"
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          branch_prefix: ${{ needs.select.outputs.branch_prefix }}
+          prompt: |
+            Implement GitHub issue #${{ needs.select.outputs.issue_number }}
+            in this repository ("${{ needs.select.outputs.issue_title }}").
+
+            Rules:
+            - Implement only what the issue's "What needs to happen" and
+              "Acceptance criteria" sections describe. Do not expand scope
+              beyond the "Files / areas touched" section without a clear,
+              stated reason.
+            - Treat the acceptance criteria checklist as the definition of
+              done. Address every item.
+            - If this repo has tests relevant to what you changed, run them
+              (see Tests/Invoke-*.ps1 for this repo's AHK test suite) before
+              finishing.
+            - Open a pull request with your changes. In the PR body:
+              - Start with a one-paragraph summary of what changed and why.
+              - If you ran relevant tests and they passed, end with
+                "Closes #${{ needs.select.outputs.issue_number }}".
+              - If you could not run tests, or they failed, or you're only
+                partially done, end with
+                "Relates to #${{ needs.select.outputs.issue_number }}"
+                instead, and explain what's incomplete or unverified.
+            - Do not merge the PR yourself. A human always reviews and
+              merges.
+          claude_args: |
+            --max-turns 25
+            --allowedTools Edit,Read,Write,Bash
+
+      - name: Label the resulting PR
+        if: always()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # gh pr list --head only matches an exact branch name, and the
+          # action picks its own suffix after our prefix, so list open PRs
+          # and filter client-side instead.
+          $prefix = "${{ needs.select.outputs.branch_prefix }}"
+          $lines = gh pr list --repo "${{ github.repository }}" --state open --json number,headRefName
+          $prs = @(($lines -join "`n") | ConvertFrom-Json)
+          $match = $prs | Where-Object { $_.headRefName.StartsWith($prefix) } | Select-Object -First 1
+          if ($match) {
+            gh pr edit $match.number --repo "${{ github.repository }}" --add-label agent-authored
+            Write-Host "Labelled PR #$($match.number) (branch $($match.headRefName)) as agent-authored."
+          } else {
+            Write-Host "No open PR found with a branch starting '$prefix' - nothing to label."
+          }
+
+      - name: On failure, free up the issue for retry
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ needs.select.outputs.issue_number }} --remove-label agent-in-progress --repo ${{ github.repository }}
+          gh issue comment ${{ needs.select.outputs.issue_number }} --repo ${{ github.repository }} --body "Automated implementation run failed (workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Removed \`agent-in-progress\` so this can be retried."

--- a/agent-plan.md
+++ b/agent-plan.md
@@ -1,0 +1,165 @@
+# Agent plan: daily ticket-implementation agent
+
+Design proposal for [#47](https://github.com/Flop0333/AutoHotkey/issues/47). This
+is the taxonomy/design doc referenced by
+[`.github/ISSUE_TEMPLATE/agent-task.yml`](.github/ISSUE_TEMPLATE/agent-task.yml)
+and by the risk labels in [`.github/labels.yml`](.github/labels.yml) — it didn't
+exist yet, so it's being created as part of this ticket.
+
+Status: **proposal, not yet implemented.** Nothing in this doc runs until a
+follow-up PR adds the actual workflow and it's reviewed.
+
+## 1. Risk taxonomy (reference)
+
+Matches the labels already in `.github/labels.yml`:
+
+| Label | Meaning | Auto-agent eligible? |
+|---|---|---|
+| `risk: read` | No state change (docs, comments, reports). | Yes |
+| `risk: reversible` | Easy-to-undo local change (code, config, a new workflow). | Yes |
+| `risk: sensitive` | Private context or meaningful external impact (secrets, external services, unattended PR creation itself). | No — human-authored only |
+| `risk: destructive` | Requires human execution. | No, never |
+
+The daily agent **only** picks up issues labeled `agent-ready` AND
+(`risk: read` OR `risk: reversible`). `sensitive`/`destructive` issues are
+filtered out at the query level, not just by convention, so a mislabeled issue
+can't slip through — see §3.
+
+## 2. Trigger
+
+```yaml
+on:
+  schedule:
+    - cron: "0 8 * * *"   # 08:00 UTC daily
+  workflow_dispatch: {}
+concurrency:
+  group: daily-ticket-agent
+  cancel-in-progress: false
+```
+
+- Daily cron, plus manual dispatch for testing/on-demand runs.
+- `concurrency` (no cancel-in-progress) prevents two runs overlapping and
+  picking the same issue twice if a manual run and the scheduled run collide.
+
+## 3. Issue selection
+
+1. Query: `gh issue list --label agent-ready --label "risk: read" --state open`
+   plus the same for `risk: reversible` (GitHub's label filter is AND, so this
+   needs two queries, unioned).
+2. Exclude any issue that already has a linked open PR (check via
+   `gh issue view <n> --json linkedBranches,timelineItems` or by searching
+   open PRs whose body contains `Closes #<n>` / `Relates to #<n>`).
+3. Exclude any issue that already carries a `agent-in-progress` label (new
+   label, added to `labels.yml` — see §7) so a slow-running task from
+   yesterday isn't picked up again before its PR lands.
+4. Sort remaining candidates: `size: S` before `size: M` before `size: L`,
+   then oldest `created_at` first within the same size. Small, old issues
+   surface first — this keeps individual runs fast and predictable.
+5. Take the first candidate. If none, log "no eligible issue" and exit 0.
+
+This logic lives in a small script (`.github/scripts/Select-AgentIssue.ps1`,
+mirroring the style of `Generate-Dashboard.ps1`) rather than inline YAML, so
+it's testable and readable.
+
+## 4. Execution / sandboxing
+
+- Runs on a GitHub-hosted `ubuntu-latest` runner — no persistent state, fresh
+  VM per run, matching `ahk-tests.yml`'s existing pattern.
+- Workflow permissions scoped to the minimum needed:
+  ```yaml
+  permissions:
+    contents: write
+    pull-requests: write
+    issues: write
+  ```
+  No `id-token`, no `pages`, no access beyond this repo.
+- Immediately after selecting an issue, the workflow:
+  1. Adds the `agent-in-progress` label to the issue (claims it, so a
+     concurrent/next-day run skips it).
+  2. Moves its Project board item to **In Progress** via the same GraphQL
+     approach `add-to-project.yml` / #49 use, reusing the existing
+     `ADD_TO_PROJECT_PAT` secret and `PROJECT_URL` variable — no new secrets
+     for board access.
+- Checks out a new branch: `agent/issue-<number>-<slugified-title>`.
+- Runs the agent (Claude Code, via `anthropics/claude-code-action` or the CLI
+  directly) with the issue's title + body as the task prompt, plus a fixed
+  system prompt: *"Implement only what's described. Follow the acceptance
+  criteria as a checklist. Do not touch files outside the listed scope
+  without a clear reason. Run any repo tests before finishing if this repo
+  has them."*
+- New secret required: `ANTHROPIC_API_KEY` (or whichever credential the
+  chosen runner needs) — this is the one new one--time setup step, documented
+  in the workflow header the same way `add-to-project.yml` documents its two.
+- Timeout: `timeout-minutes: 20` on the job, so a stuck run doesn't hang the
+  daily schedule indefinitely.
+- After the agent finishes: run the existing test suite
+  (`Tests/Invoke-SyntaxCheck.ps1`, `Invoke-UnitTests.ps1`,
+  `Invoke-IntegrationTests.ps1`) locally in the job *before* pushing. If tests
+  fail, the workflow does **not** open a PR — it pushes the branch anyway (for
+  inspection) and comments on the issue explaining the run failed its own
+  tests, removing `agent-in-progress` so it can be retried.
+
+## 5. PR format
+
+- Title: `<issue title>` (drop the `[Task]:` prefix).
+- Body:
+  ```
+  Implements #<number>.
+
+  <one-paragraph summary the agent writes of what it changed and why>
+
+  ---
+  Opened automatically by the daily ticket agent from #47.
+  Closes #<number>.
+  ```
+- `Closes #<number>` is only included if the agent's own test run passed —
+  otherwise the PR (if opened at all) uses `Relates to #<number>` so merging
+  doesn't silently close an issue whose acceptance criteria aren't actually
+  met.
+- Labelled `agent-authored` (new label, see §7) so the PR-review agent (#48)
+  and dashboard enrichment (#53) can identify it without guessing from branch
+  name.
+- **Never auto-merged.** A human always reviews and merges. This is the
+  primary safety rail: the agent can open a PR, but nothing lands on `main`
+  without a person clicking merge.
+
+## 6. Failure modes handled
+
+| Situation | Behavior |
+|---|---|
+| No eligible issue | Exit 0, no PR, no label changes. |
+| Agent produces no diff | Comment on the issue explaining nothing changed, remove `agent-in-progress`, no PR. |
+| Agent's own tests fail | Push branch for inspection, comment with failure summary, remove `agent-in-progress`, no `Closes` keyword. |
+| Job times out | `agent-in-progress` label is left on — a human notices and manually clears it or the next run's staleness check (see below) removes labels older than 24h before selecting. |
+| Issue was closed/edited mid-run | Not specifically detected in v1; the PR still opens referencing the issue number, human review catches the mismatch. Worth hardening later if it happens in practice. |
+
+## 7. New labels
+
+Add to `.github/labels.yml` (synced automatically by the existing
+`sync-labels.yml`):
+
+- `agent-in-progress` — an automated agent has claimed this issue and is
+  working on it.
+- `agent-authored` — this PR was opened by the daily ticket agent, not a
+  human.
+
+## 8. Out of scope for v1
+
+- Auto-merging (never — always manual).
+- Handling `risk: sensitive`/`risk: destructive` issues at all.
+- Picking more than one issue per run.
+- Retrying a failed run automatically (a human re-triggers via
+  `workflow_dispatch` after fixing whatever broke).
+
+## 9. Open questions for review
+
+1. **Agent runner**: use `anthropics/claude-code-action`, or shell out to the
+   `claude` CLI directly on the runner? The action is less code to maintain;
+   the CLI gives more control over exact flags. Leaning toward the action
+   unless there's a reason not to.
+2. **Schedule time**: 08:00 UTC is a placeholder — happy to change to
+   whenever fits best.
+3. **`size: L` issues**: proposal excludes them implicitly by sort order but
+   doesn't hard-block them — should `size: L` be excluded entirely from
+   auto-pickup (multi-session work seems like a bad fit for one unattended
+   run), leaving it purely for size S/M?

--- a/agent-plan.md
+++ b/agent-plan.md
@@ -46,16 +46,33 @@ concurrency:
 1. Query: `gh issue list --label agent-ready --label "risk: read" --state open`
    plus the same for `risk: reversible` (GitHub's label filter is AND, so this
    needs two queries, unioned).
-2. Exclude any issue that already has a linked open PR (check via
-   `gh issue view <n> --json linkedBranches,timelineItems` or by searching
-   open PRs whose body contains `Closes #<n>` / `Relates to #<n>`).
-3. Exclude any issue that already carries a `agent-in-progress` label (new
+2. Filter to `size: S` or `size: M` only — `size: L` issues are hard-excluded
+   from auto-pickup (see §9); they always need a human to kick off.
+3. Exclude any issue that already carries an `agent-in-progress` label (new
    label, added to `labels.yml` — see §7) so a slow-running task from
-   yesterday isn't picked up again before its PR lands.
-4. Sort remaining candidates: `size: S` before `size: M` before `size: L`,
-   then oldest `created_at` first within the same size. Small, old issues
-   surface first — this keeps individual runs fast and predictable.
+   yesterday isn't picked up again before its PR lands. **Simplification vs.
+   the original proposal**: dropped the separate "exclude if already has a
+   linked open PR" check — GitHub doesn't expose a simple, reliable way to
+   query that (Projects/timeline APIs are either preview-only or fragile to
+   parse), and `agent-in-progress` already prevents the one case that check
+   was really guarding against (the daily agent re-picking its own
+   in-flight work). A human opening a competing PR against the same issue
+   independently is an acceptable edge case for v1 — it just means the
+   agent's PR and the human's PR both reference the same issue, which a
+   reviewer resolves normally.
+4. Sort remaining candidates: `size: S` before `size: M`, then oldest
+   `created_at` first within the same size. Small, old issues surface first —
+   this keeps individual runs fast and predictable.
 5. Take the first candidate. If none, log "no eligible issue" and exit 0.
+
+Implemented in
+[`.github/scripts/Select-AgentIssue.ps1`](.github/scripts/Select-AgentIssue.ps1).
+Note for anyone touching this script: avoid `Sort-Object <property> -Unique`
+on objects built from `ConvertFrom-Json` — it was found (by hand, while
+building this) to silently drop legitimate entries when combining a
+single-object JSON result with an array JSON result, which is exactly the
+shape two `gh issue list` calls with different result counts produce. Dedupe
+explicitly with a hashtable instead, as the script does.
 
 This logic lives in a small script (`.github/scripts/Select-AgentIssue.ps1`,
 mirroring the style of `Generate-Dashboard.ps1`) rather than inline YAML, so
@@ -76,10 +93,16 @@ it's testable and readable.
 - Immediately after selecting an issue, the workflow:
   1. Adds the `agent-in-progress` label to the issue (claims it, so a
      concurrent/next-day run skips it).
-  2. Moves its Project board item to **In Progress** via the same GraphQL
-     approach `add-to-project.yml` / #49 use, reusing the existing
-     `ADD_TO_PROJECT_PAT` secret and `PROJECT_URL` variable — no new secrets
-     for board access.
+  2. Moves its Project board item to **In Progress** via
+     [`.github/scripts/Set-BoardStatus.ps1`](.github/scripts/Set-BoardStatus.ps1)
+     (Projects v2 GraphQL, written for this ticket and reusable by #49),
+     reusing the existing `ADD_TO_PROJECT_PAT` secret and `PROJECT_URL`
+     variable — no new secrets for board access. Note for anyone reusing
+     this script: `gh api graphql`'s `-f query=<text>` mangles a query
+     containing double quotes when the value is built up in PowerShell and
+     forwarded to the native `gh.exe`; pass the query from a temp file via
+     `-F query=@<path>` instead (`-F`, not `-f` — only `-F/--field` supports
+     the `@file` form). Found by hand while building this.
 - Checks out a new branch: `agent/issue-<number>-<slugified-title>`.
 - Runs the agent (Claude Code, via `anthropics/claude-code-action` or the CLI
   directly) with the issue's title + body as the task prompt, plus a fixed
@@ -151,15 +174,11 @@ Add to `.github/labels.yml` (synced automatically by the existing
 - Retrying a failed run automatically (a human re-triggers via
   `workflow_dispatch` after fixing whatever broke).
 
-## 9. Open questions for review
+## 9. Decisions (resolved 2026-09-07)
 
-1. **Agent runner**: use `anthropics/claude-code-action`, or shell out to the
-   `claude` CLI directly on the runner? The action is less code to maintain;
-   the CLI gives more control over exact flags. Leaning toward the action
-   unless there's a reason not to.
-2. **Schedule time**: 08:00 UTC is a placeholder — happy to change to
-   whenever fits best.
-3. **`size: L` issues**: proposal excludes them implicitly by sort order but
-   doesn't hard-block them — should `size: L` be excluded entirely from
-   auto-pickup (multi-session work seems like a bad fit for one unattended
-   run), leaving it purely for size S/M?
+1. **Agent runner**: `anthropics/claude-code-action`.
+2. **Schedule time**: 08:00 UTC, as proposed.
+3. **`size: L` issues**: hard-excluded from auto-pickup. The selection query
+   (§3) filters to `size: S` or `size: M` only — `size: L` issues are never
+   eligible for unattended pickup regardless of age, and always need a human
+   to kick off manually.


### PR DESCRIPTION
Implements #47.

Adds `.github/workflows/daily-agent.yml`, `.github/scripts/Select-AgentIssue.ps1`, and `.github/scripts/Set-BoardStatus.ps1` per the design in [`agent-plan.md`](../blob/feature/47-daily-ticket-agent/agent-plan.md) (reviewed on #47 before this was written; the three open questions there were resolved: `anthropics/claude-code-action`, 08:00 UTC, and `size: L` hard-excluded).

**What it does**: daily (+ manual dispatch), picks one open issue labeled `agent-ready` with `risk: read` or `risk: reversible` and `size: S` or `size: M`, not already `agent-in-progress`. Claims it (label + moves the board card to "In Progress"), runs Claude Code against it, and expects a PR back referencing the issue. Never auto-merges.

**Testing**: `Select-AgentIssue.ps1` and `Set-BoardStatus.ps1` were both hand-run against this repo's real issues and the real project board while writing them (not just read — actually exercised), which caught three real bugs before any of this touched CI:
- `gh api graphql -f query="..."` mangles embedded double quotes when PowerShell forwards the argument to `gh.exe` — fixed by passing the query via a temp file with `-F query=@file` (`-F`, not `-f`).
- `Sort-Object <prop> -Unique` silently dropped a legitimate issue when deduping two `ConvertFrom-Json` results of different sizes — replaced with an explicit hashtable dedup.
- `gh pr list --head` needs an exact branch name (no globbing) — switched to listing open PRs and filtering by prefix client-side.

A manual re-read before pushing also caught a job-permissions gap (the `select` job's `permissions: issues: read` implicitly zeroes `contents`, which would've broken `actions/checkout`) and a step trying to read its own `steps.*.outputs` mid-run (not possible — outputs aren't available until the step finishes).

**What's not verified**: the `anthropics/claude-code-action` step itself — I don't have a way to run a real GitHub Actions job from here. This needs a live test.

## Before this goes live

1. Add repo secret `ANTHROPIC_API_KEY` (Settings → Secrets and variables → Actions).
2. Run it once by hand: Actions tab → "Daily ticket agent" → Run workflow. Check it picks a sensible issue, the PR it opens looks right, and labels/board update as expected.
3. Only then trust the daily 08:00 UTC schedule.

Not closing #47 on merge — leaving that to you once a real run has actually produced a working PR, since that's the real proof this does what it's supposed to.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>