### PR TITLE
Implement PR review, board sync, idea triage, and stale-nudge agents

### DIFF
--- a/.github/scripts/Invoke-GitHubGraphQL.ps1
+++ b/.github/scripts/Invoke-GitHubGraphQL.ps1
@@ -1,0 +1,36 @@
+<#
+Shared helper for GitHub GraphQL calls. Dot-source this file, then call
+Invoke-GitHubGraphQL. Used by Set-BoardStatus.ps1 and
+Close-IssueIfBoardDone.ps1 - anything that needs to talk to the Projects v2
+API, which has no simple REST equivalent.
+#>
+
+function Invoke-GitHubGraphQL {
+    param(
+        [Parameter(Mandatory)] [string]$Query,
+        [hashtable]$Variables = @{}
+    )
+
+    # Passed via a temp file, not inline -f query="...", because
+    # PowerShell's argument marshalling to the native gh.exe mangles
+    # embedded double quotes (e.g. `name: "Status"`), producing invalid
+    # GraphQL. -F (not -f) is required: only -F/--field does the "@file
+    # reads the value from a file" substitution that -f/--raw-field lacks.
+    # Found by hand while building the daily ticket agent (#47).
+    $queryFile = New-TemporaryFile
+    Set-Content -Path $queryFile -Value $Query -NoNewline
+    try {
+        $ghArgs = @("api", "graphql", "-F", "query=@$queryFile")
+        foreach ($key in $Variables.Keys) {
+            $isInt = $Variables[$key] -is [int]
+            $flag = if ($isInt) { "-F" } else { "-f" }
+            $ghArgs += $flag
+            $ghArgs += "$key=$($Variables[$key])"
+        }
+        $out = gh @ghArgs
+        if ($LASTEXITCODE -ne 0) { throw "gh api graphql failed: $out" }
+        $out | ConvertFrom-Json
+    } finally {
+        Remove-Item $queryFile -ErrorAction SilentlyContinue
+    }
+}

--- a/.github/scripts/Select-AgentIssue.ps1
+++ b/.github/scripts/Select-AgentIssue.ps1
@@ -21,7 +21,15 @@ function Get-CandidateIssues($riskLabel) {
     # PowerShell captures native stdout as a string array (one element per
     # line); ConvertFrom-Json needs it rejoined into one string first, or
     # pretty-printed/multi-line JSON parses into garbage silently.
-    ($lines -join "`n") | ConvertFrom-Json
+    #
+    # Also must be two statements, not `return ($lines -join "`n") |
+    # ConvertFrom-Json`: a function whose last statement is that pipeline
+    # expression, called as @(Get-CandidateIssues ...), produces a
+    # 1-element array wrapping an empty array when there are zero results,
+    # not a 0-element array - @() only flattens an already-materialized
+    # array variable, not a pipeline's output. Verified by hand.
+    $parsed = ($lines -join "`n") | ConvertFrom-Json
+    @($parsed)
 }
 
 $combined = @(Get-CandidateIssues "risk: read") + @(Get-CandidateIssues "risk: reversible")

--- a/.github/scripts/Send-StaleNudges.ps1
+++ b/.github/scripts/Send-StaleNudges.ps1
@@ -1,0 +1,58 @@
+<#
+Nudges issues labeled needs-human-decision that have gone quiet for a while.
+See .github/workflows/stale-nudges.yml and issue #51.
+
+Uses the issue's updatedAt as the staleness clock rather than tracking
+separate state: posting a nudge comment bumps updatedAt, which naturally
+prevents re-nudging the same issue again until another $DaysThreshold days
+of silence pass. Any other activity (a human comment, a relabel) also
+resets the clock, which is the desired behavior - it means the issue isn't
+stale anymore.
+#>
+param(
+    [Parameter(Mandatory)] [string]$Repo,   # e.g. "Flop0333/AutoHotkey"
+    [int]$DaysThreshold = 14
+)
+
+$ErrorActionPreference = "Stop"
+
+$lines = gh issue list --repo $Repo --state open --label "needs-human-decision" `
+    --json number,title,updatedAt --limit 100
+if ($LASTEXITCODE -ne 0) { throw "gh issue list failed" }
+# Must be two statements, not `@((...) | ConvertFrom-Json)`: wrapping a
+# pipeline expression directly with @() does not flatten it the way
+# wrapping an already-materialized array variable does - on an empty JSON
+# array this produces a 1-element array containing an empty array, not a
+# 0-element array. Verified by hand while building this.
+$parsedIssues = ($lines -join "`n") | ConvertFrom-Json
+$issues = @($parsedIssues)
+
+if ($issues.Count -eq 0) {
+    Write-Host "No open needs-human-decision issues - nothing to check."
+    exit 0
+}
+
+$now = (Get-Date).ToUniversalTime()
+$nudged = @()
+
+foreach ($issue in $issues) {
+    $updated = [datetime]$issue.updatedAt
+    $ageDays = [math]::Floor(($now - $updated).TotalDays)
+
+    if ($ageDays -lt $DaysThreshold) {
+        Write-Host "Skipping #$($issue.number): idle $ageDays`d, under the $DaysThreshold`d threshold."
+        continue
+    }
+
+    $body = "This has been labeled ``needs-human-decision`` with no activity for $ageDays days. Flagging it in case it's been missed - no other action taken."
+    gh issue comment $issue.number --repo $Repo --body $body
+    if ($LASTEXITCODE -ne 0) { throw "Failed to comment on #$($issue.number)" }
+    Write-Host "Nudged #$($issue.number) (idle $ageDays`d): $($issue.title)"
+    $nudged += $issue.number
+}
+
+if ($nudged.Count -eq 0) {
+    Write-Host "Checked $($issues.Count) issue(s), none past the $DaysThreshold-day threshold."
+} else {
+    Write-Host "Nudged $($nudged.Count) issue(s): $($nudged -join ', ')"
+}

--- a/.github/scripts/Set-BoardStatus.ps1
+++ b/.github/scripts/Set-BoardStatus.ps1
@@ -17,6 +17,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+. "$PSScriptRoot/Invoke-GitHubGraphQL.ps1"
 
 if ($ProjectUrl -notmatch '^https://github\.com/(users|orgs)/([^/]+)/projects/(\d+)/?$') {
     throw "PROJECT_URL '$ProjectUrl' doesn't look like a Project (v2) URL (expected https://github.com/users|orgs/<owner>/projects/<number>)."
@@ -25,30 +26,6 @@ $ownerType = $Matches[1]   # "users" or "orgs"
 $owner = $Matches[2]
 $projectNumber = [int]$Matches[3]
 $ownerField = if ($ownerType -eq "users") { "user" } else { "organization" }
-
-function Invoke-GraphQL($query, [hashtable]$vars) {
-    # Passed via a temp file, not inline -f query="...", because PowerShell's
-    # argument marshalling to the native gh.exe mangles embedded double
-    # quotes (e.g. `name: "Status"`), producing invalid GraphQL.
-    $queryFile = New-TemporaryFile
-    Set-Content -Path $queryFile -Value $query -NoNewline
-    try {
-        # -F (not -f) is required here: only -F/--field does the "@file reads
-        # the value from a file" substitution that -f/--raw-field lacks.
-        $args = @("api", "graphql", "-F", "query=@$queryFile")
-        foreach ($key in $vars.Keys) {
-            $isInt = $vars[$key] -is [int]
-            $flag = if ($isInt) { "-F" } else { "-f" }
-            $args += $flag
-            $args += "$key=$($vars[$key])"
-        }
-        $out = gh @args
-        if ($LASTEXITCODE -ne 0) { throw "gh api graphql failed: $out" }
-        $out | ConvertFrom-Json
-    } finally {
-        Remove-Item $queryFile -ErrorAction SilentlyContinue
-    }
-}
 
 $projectQuery = @"
 query(`$owner: String!, `$number: Int!) {
@@ -65,7 +42,7 @@ query(`$owner: String!, `$number: Int!) {
   }
 }
 "@
-$result = Invoke-GraphQL $projectQuery @{ owner = $owner; number = $projectNumber }
+$result = Invoke-GitHubGraphQL -Query $projectQuery -Variables @{ owner = $owner; number = $projectNumber }
 $project = $result.data.$ownerField.projectV2
 if (-not $project) { throw "Could not find project $projectNumber for $ownerType/$owner - check PROJECT_URL." }
 
@@ -86,6 +63,6 @@ mutation(`$project: ID!, `$item: ID!, `$field: ID!, `$option: String!) {
   }) { projectV2Item { id } }
 }
 "@
-Invoke-GraphQL $mutation @{ project = $project.id; item = $item.id; field = $project.field.id; option = $option.id } | Out-Null
+Invoke-GitHubGraphQL -Query $mutation -Variables @{ project = $project.id; item = $item.id; field = $project.field.id; option = $option.id } | Out-Null
 
 Write-Host "Moved issue #$IssueNumber to '$Status' on the board."

--- a/.github/workflows/daily-agent.yml
+++ b/.github/workflows/daily-agent.yml
@@ -115,7 +115,15 @@ jobs:
           # and filter client-side instead.
           $prefix = "${{ needs.select.outputs.branch_prefix }}"
           $lines = gh pr list --repo "${{ github.repository }}" --state open --json number,headRefName
-          $prs = @(($lines -join "`n") | ConvertFrom-Json)
+          # Two statements, not `@((...) | ConvertFrom-Json)`: wrapping a
+          # pipeline expression directly with @() doesn't flatten it like
+          # wrapping an already-materialized array variable does - with
+          # zero open PRs this produced a 1-element array wrapping an empty
+          # array, and $_.headRefName below then threw on that phantom
+          # element instead of finding no match. Found and fixed while
+          # building the #48-51 workflows, which hit the same pattern.
+          $parsedPrs = ($lines -join "`n") | ConvertFrom-Json
+          $prs = @($parsedPrs)
           $match = $prs | Where-Object { $_.headRefName.StartsWith($prefix) } | Select-Object -First 1
           if ($match) {
             gh pr edit $match.number --repo "${{ github.repository }}" --add-label agent-authored

--- a/.github/workflows/idea-triage.yml
+++ b/.github/workflows/idea-triage.yml
@@ -1,0 +1,74 @@
+name: Idea triage agent
+
+# Requires the same ANTHROPIC_API_KEY secret as daily-agent.yml (see that
+# workflow's header).
+#
+# Deliberately restricted to Bash/Read/Grep/Glob (no Edit/Write): this
+# agent only ever changes issue metadata (labels, body, comments) via the
+# gh CLI - it has no reason to touch any file in the repository checkout,
+# so it isn't given the tools to.
+
+on:
+  # Weekly, Monday 07:00 UTC - ahead of stale-nudges.yml's 09:00 run, so a
+  # freshly-triaged needs-human-decision issue isn't immediately flagged as
+  # stale by that workflow.
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Claude Code triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            List open issues in ${{ github.repository }} labeled "idea"
+            that do NOT also carry "needs-human-decision":
+            `gh issue list --repo ${{ github.repository }} --state open --label idea --json number,title,body,labels`,
+            then filter out any result whose labels already include
+            "needs-human-decision".
+
+            For each remaining issue, decide whether it's concrete enough
+            to scope into an actionable task. The target shape is
+            .github/ISSUE_TEMPLATE/agent-task.yml (What needs to happen /
+            Acceptance criteria / Files-areas touched / Risk level / Size
+            estimate).
+
+            If it IS scopable:
+            - Rewrite the issue body with `gh issue edit --body` to follow
+              that template's structure (matching ### headers), grounded
+              only in what the idea actually describes - do not invent
+              requirements it doesn't support.
+            - Pick one risk label (risk: read / risk: reversible /
+              risk: sensitive / risk: destructive) and one size label
+              (size: S / size: M / size: L) - see .github/labels.yml for
+              what each means.
+            - Replace the "idea" label with "agent-ready" plus the risk
+              and size labels you picked (`gh issue edit --add-label
+              --remove-label`).
+            - Leave a comment noting it was auto-triaged, summarizing the
+              risk/size you picked and why, so a human can sanity-check
+              your judgment before it's ever picked up for implementation.
+
+            If it is NOT scopable (genuinely needs a judgment call, is too
+            vague, or depends on something only a human would know):
+            - Do not force a scope onto it or guess acceptance criteria it
+              doesn't support.
+            - Add the "needs-human-decision" label, keeping "idea".
+            - Leave a comment explaining specifically what's missing or
+              what decision is needed - not just "too vague".
+
+            Never close, merge, or delete anything. Never touch an issue
+            that isn't labeled "idea", and never touch pull requests.
+          claude_args: |
+            --max-turns 30
+            --allowedTools Bash,Read,Grep,Glob

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,73 @@
+name: PR review agent
+
+# Requires the same ANTHROPIC_API_KEY secret as daily-agent.yml (see that
+# workflow's header). Advisory only: posts a COMMENT-event review, never
+# APPROVE or REQUEST_CHANGES, so it can never block or approve a PR itself.
+#
+# Dedup approach for re-pushes (issue #48's "doesn't spam duplicate
+# comments" requirement): on `synchronize`, the prompt tells Claude to find
+# its own prior review (if any) and only review the diff since that
+# review's commit, not the whole PR again. This is a prompt-level
+# instruction, not something a script enforces - not fully verified
+# without a live multi-push test, same caveat as daily-agent.yml's Claude
+# Code step.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review pull request #${{ github.event.pull_request.number }}
+            in ${{ github.repository }} (head commit
+            ${{ github.event.pull_request.head.sha }}).
+
+            Scope: correctness bugs, and simplification/efficiency/reuse
+            cleanups - the bar a careful human reviewer would use. Do not
+            comment on style nits or anything a linter would already catch.
+
+            Steps:
+            1. Check for a review you (this GitHub Actions bot identity)
+               already left on this PR:
+               `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews`.
+            2. If none exists, review the full PR diff:
+               `gh pr diff ${{ github.event.pull_request.number }}`.
+            3. If one already exists, only review what changed between
+               that review's commit_id and the current head commit - do
+               not re-flag findings in code that hasn't changed since your
+               last review on this PR.
+            4. If you find issues, submit exactly one review with inline
+               comments in a single call:
+               `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews`
+               (POST, event=COMMENT, a comments[] array with one
+               {path, line, body} entry per finding) - not separate API
+               calls per finding, and not one comment body listing
+               everything.
+            5. If you find nothing (whether reviewing the full diff or
+               just the incremental one), submit a short COMMENT-event
+               review with a body like "No issues found in this review."
+               so there's a visible record the review ran.
+            6. Never use event=REQUEST_CHANGES or event=APPROVE - COMMENT
+               only, always. Never edit any files in this repository.
+          claude_args: |
+            --max-turns 20
+            --allowedTools Bash,Read,Grep,Glob

--- a/.github/workflows/stale-nudges.yml
+++ b/.github/workflows/stale-nudges.yml
@@ -1,0 +1,20 @@
+name: Stale needs-human-decision nudges
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # weekly, Monday 09:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./.github/scripts/Send-StaleNudges.ps1 -Repo "${{ github.repository }}"

--- a/.github/workflows/sync-board-status.yml
+++ b/.github/workflows/sync-board-status.yml
@@ -1,0 +1,47 @@
+name: Sync board status on reopen
+
+# Scope note (read before "fixing" this to also handle Done <-> closed):
+#
+# Issue #49 originally asked for three behaviors:
+#   1. Board Status set to "Done" -> issue closes.
+#   2. Issue closed -> board Status set to "Done".
+#   3. Issue reopened -> board Status moves off "Done".
+#
+# While building this, (1) and (2) turned out to already be native GitHub
+# Projects (v2) workflows configured on this board - confirmed by hand:
+# setting a test issue's Status to Done auto-closed it, and separately
+# closing a test issue auto-set its Status to Done, both without any of
+# this repo's code involved. Adding a custom handler for either would
+# duplicate the platform's own automation and can race with it (an early
+# version of this hit "issue is already closed" doing exactly that).
+#
+# So this workflow only covers (3), the one gap: reopening an issue does
+# NOT revert its Status off "Done" on its own. "Todo" was chosen as the
+# reset target (a plain "sensible default", per the ticket) rather than
+# trying to reconstruct whatever status preceded "Done".
+#
+# If this board's native workflows are ever turned off, (1) and (2) would
+# need to move into custom automation too - see the reverted portions of
+# this ticket's history for a starting point (GraphQL query for reading an
+# item's Status + linked issue state, keyed off `projects_v2_item` events).
+
+on:
+  issues:
+    types: [reopened]
+
+jobs:
+  reset-status:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          ./.github/scripts/Set-BoardStatus.ps1 `
+            -ProjectUrl "${{ vars.PROJECT_URL }}" `
+            -IssueNumber ${{ github.event.issue.number }} `
+            -Status "Todo"


### PR DESCRIPTION
Implements #48, #49, #50, #51.

Four independent workflows, all following the pattern established in #47 (`anthropics/claude-code-action` for the ones that need judgment, plain PowerShell scripts for the ones that don't). All were hand-tested against the real repo/board with disposable test issues (created, exercised, deleted) rather than just read through — that caught a real bug and one significant scope correction before either touched CI.

## #51 — Stale needs-human-decision nudges
`stale-nudges.yml` + `Send-StaleNudges.ps1`. Weekly, comments on `needs-human-decision` issues idle 14+ days. Uses `updatedAt` as the staleness clock instead of tracking separate state — a nudge comment bumps it, which naturally prevents re-nudging until another 14 days pass.

**Bug found and fixed** (also present in the already-merged `daily-agent.yml` — fixed there too): `@((...) | ConvertFrom-Json)` doesn't flatten the way `@($alreadyAssignedVariable)` does. On an empty JSON array it produces a 1-element array wrapping an empty array instead of a 0-element array, which then crashes on property access against the phantom element. Fixed by always assigning to a variable before wrapping with `@()`. Verified against the real zero-results case for both scripts.

## #49 — Sync board status on reopen
Scoped down significantly from the original ask after testing against the real board. Two of the three requested behaviors ("Status → Done closes the issue" and "issue closed → Status set to Done") turned out to already be **native GitHub Projects (v2) workflows already configured on this board** — confirmed by creating throwaway test issues and watching it happen with zero custom code involved. An early version duplicating that logic visibly raced the native automation. Building custom automation for behavior the platform already provides added risk with no benefit, so `sync-board-status.yml` only implements the actual gap: reopening an issue doesn't revert its Status off "Done" on its own — this resets it to "Todo".

Also extracted `Invoke-GitHubGraphQL.ps1` out of `Set-BoardStatus.ps1` (previously inlined) since a second script needed the same "pass the query via temp file, not inline" logic — reduces the chance of that quoting workaround diverging across copies.

## #48 — PR review agent
`pr-review.yml`. Runs on every PR open/synchronize, posts one inline review (COMMENT event only — can never approve or block). Restricted to `Bash,Read,Grep,Glob` (no Edit/Write) since it has no legitimate reason to modify repo files. Dedup on re-push (don't re-flag unchanged findings) is a prompt-level instruction, not script-enforced — no simple deterministic way to do that from the workflow side.

## #50 — Idea triage agent
`idea-triage.yml`. Weekly, scans open `idea` issues, rewrites scopable ones into the `agent-task` template shape with `agent-ready` + risk/size labels, or adds `needs-human-decision` with an explanation when something genuinely isn't scopable yet. Same tool restriction as #48 (no Edit/Write — it only ever touches issue metadata via `gh`). Scheduled an hour ahead of `stale-nudges.yml` so a freshly-triaged issue isn't immediately flagged as stale.

## What's not verified
Same caveat as #47: the actual `claude-code-action` steps in `pr-review.yml` and `idea-triage.yml` haven't run for real — I have no way to trigger a live GitHub Actions job from here. Everything deterministic (both PowerShell scripts, the board-sync logic) was hand-run against the real repo and board.

## Before merging
- `ANTHROPIC_API_KEY` still needs to be added (you mentioned doing this later) before any of these can actually run their Claude Code steps.
- Worth a manual `workflow_dispatch` test of `idea-triage.yml` and `stale-nudges.yml`, and a real PR to exercise `pr-review.yml`, before trusting the schedules.

Not closing #48–#51 on merge — leaving that to you once each has had a real run.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>