### PR TITLE
Fix DateTime.Substring() crash in dashboard generation

### DIFF
--- a/.github/scripts/Generate-Dashboard.ps1
+++ b/.github/scripts/Generate-Dashboard.ps1
@@ -47,7 +47,7 @@ function Format-IssueRows($issues) {
     }
     ($issues | ForEach-Object {
         $labels = ($_.labels | ForEach-Object { $_.name }) -join ", "
-        "<tr><td><a href='$($_.html_url)'>#$($_.number) $($_.title)</a></td><td>$labels</td><td>$($_.updated_at.Substring(0,10))</td></tr>"
+        "<tr><td><a href='$($_.html_url)'>#$($_.number) $($_.title)</a></td><td>$labels</td><td>$(([datetime]$_.updated_at).ToString('yyyy-MM-dd'))</td></tr>"
     }) -join "`n"
 }
 
@@ -58,7 +58,7 @@ function Format-RunRows($runs) {
     ($runs | ForEach-Object {
         $status = if ($_.conclusion) { $_.conclusion } else { $_.status }
         $cls = switch ($status) { "success" { "ok" }; "failure" { "fail" }; default { "pending" } }
-        "<tr><td><a href='$($_.html_url)'>$($_.display_title)</a></td><td class='$cls'>$status</td><td>$($_.created_at.Substring(0,16).Replace('T',' '))</td></tr>"
+        "<tr><td><a href='$($_.html_url)'>$($_.display_title)</a></td><td class='$cls'>$status</td><td>$(([datetime]$_.created_at).ToString('yyyy-MM-dd HH:mm'))</td></tr>"
     }) -join "`n"
 }
 
@@ -84,7 +84,7 @@ function Format-AgentPRRows($prs) {
     ($prs | Sort-Object created_at -Descending | Select-Object -First 10 | ForEach-Object {
         $status = if ($_.merged_at) { "merged" } else { "closed" }
         $cls = if ($_.merged_at) { "ok" } else { "fail" }
-        "<tr><td><a href='$($_.html_url)'>#$($_.number) $($_.title)</a></td><td class='$cls'>$status</td><td>$($_.created_at.Substring(0,10))</td></tr>"
+        "<tr><td><a href='$($_.html_url)'>#$($_.number) $($_.title)</a></td><td class='$cls'>$status</td><td>$(([datetime]$_.created_at).ToString('yyyy-MM-dd'))</td></tr>"
     }) -join "`n"
 }
 


### PR DESCRIPTION
Fixes #46.

Root cause confirmed exactly as described in the ticket, via the linked failed run: PowerShell 7's `ConvertFrom-Json` (used by `dashboard.yml`'s `pwsh` step) parses recognizable ISO 8601 date strings (`created_at`/`updated_at`) into `[datetime]` objects rather than leaving them as strings. Verified locally that Windows PowerShell 5.1 does *not* do this for the same JSON (returns a plain string) — which is presumably why this only surfaced on CI's `pwsh`, not in any local testing.

Fixed all three occurrences of this pattern in the file, not just the one that actually crashed:
- `Format-RunRows` — the one in #46's report.
- `Format-IssueRows` — same pattern, same latent bug, hadn't crashed yet.
- `Format-AgentPRRows` — added in #53's PR-activity feature; never exercised with real date data since that ticket's testing only hit the empty-state path (zero agent-authored PRs existed at the time). Same bug, just not yet triggered.

Replaced `$_.field.Substring(...)` with `([datetime]$_.field).ToString(...)` everywhere — works whether the value comes through as a string or an already-parsed DateTime, so it can't regress the same way again if PowerShell's JSON behavior shifts further.

**Tested against the real GitHub API** (not just read through): ran the full script with a live token, confirmed the previously-crashing run rows and the other two date columns all render correctly now, plus a syntax check pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>