### PR TITLE
Fix silent startup failures, dead Logger popup deferral, and array secret values

### DIFF
--- a/Dashboards/Log Dashboard/Controller.ahk
+++ b/Dashboards/Log Dashboard/Controller.ahk
@@ -3,11 +3,12 @@
 
 Class LogDashboard extends WebViewToo {
 	static WIN_TITLE := "AutoHotkey Error Logger - Log Dashboard"
+	static INITIALIZING_TITLE := "AutoHotkey Log Dashboard - Initializing"
 	static SHOW_OPTIONS := Format("w{} h{}", Round(A_ScreenWidth * 0.85), Round(A_ScreenHeight * 0.75))
 
 	__New() {
 		super.__New()
-		this.Gui.Title := LogDashboard.WIN_TITLE
+		this.Gui.Title := LogDashboard.INITIALIZING_TITLE
 		this.Gui.OnEvent("Close", (*) => this.Hide())
 		this.SetVirtualHostNameToFolderMapping("app.local", Paths.dashboards "\Log Dashboard\User Interface", 0) ; block cors error, allow loading local files
 		this.Load("http://app.local/index.html")
@@ -24,7 +25,14 @@ Class LogDashboard extends WebViewToo {
 	}
 
 	Show() => super.Show(LogDashboard.SHOW_OPTIONS, LogDashboard.WIN_TITLE)
-	InitializeHidden() => super.Show("Hide " LogDashboard.SHOW_OPTIONS, LogDashboard.WIN_TITLE)
+
+	InitializeHidden() {
+		; WIN_TITLE is also the cross-process readiness signal. Publish it only
+		; after the initial Hide has completed so a waiting caller cannot show
+		; this window just before the host hides it again.
+		super.Show("Hide " LogDashboard.SHOW_OPTIONS, LogDashboard.INITIALIZING_TITLE)
+		this.Gui.Title := LogDashboard.WIN_TITLE
+	}
 
 	Close() => this.Hide()
 

--- a/Dashboards/Log Dashboard/Controller.ahk
+++ b/Dashboards/Log Dashboard/Controller.ahk
@@ -15,6 +15,12 @@ Class LogDashboard extends WebViewToo {
 		this.AddCallbackToScript("SetClipboard", (webview, text) => A_Clipboard := text)
 		this.AddCallbackToScript("LogTestMessage", (webview, severity) => this.LogTestMessage(severity))
 		this.AddCallbackToScript("GetGitStatus", (*) => this.GetGitStatusForWeb())
+		this.AddCallbackToScript("OpenLogArchive", (*) => this.OpenLogArchive())
+	}
+
+	OpenLogArchive() {
+		DirCreate(ErrorLogArchiveDirectory())
+		Run('explorer.exe "' ErrorLogArchiveDirectory() '"')
 	}
 
 	Show() => super.Show(LogDashboard.SHOW_OPTIONS, LogDashboard.WIN_TITLE)
@@ -23,16 +29,7 @@ Class LogDashboard extends WebViewToo {
 	Close() => this.Hide()
 
 	GetLogEntriesForWeb() {
-		entries := []
-		if !FileExist(ErrorLogFile())
-			return JSON.Dump(entries)
-
-		for line in StrSplit(FileRead(ErrorLogFile(), "UTF-8"), "`n", "`r") {
-			if (Trim(line) = "")
-				continue
-			try entries.Push(JSON.parse(line))
-		}
-		return JSON.Dump(entries)
+		return JSON.Dump(ReadLogEntries())
 	}
 
 	static TestMessages := Map(

--- a/Dashboards/Log Dashboard/User Interface/AhkDataService.js
+++ b/Dashboards/Log Dashboard/User Interface/AhkDataService.js
@@ -7,4 +7,6 @@ class AhkDataService {
   static LogTestMessage = (severity) => ahk.LogTestMessage(severity);
 
   static GetGitStatus = () => ahk.GetGitStatus().then(JSON.parse);
+
+  static OpenLogArchive = () => ahk.OpenLogArchive();
 }

--- a/Dashboards/Log Dashboard/User Interface/index.html
+++ b/Dashboards/Log Dashboard/User Interface/index.html
@@ -22,6 +22,7 @@
     <select id="severity-filter"><option value="">All severities</option></select>
     <select id="script-filter"><option value="">All scripts</option></select>
     <button id="sort-time">Time ↓</button>
+	<button id="open-archive" title="Open archived logs from earlier sessions">Earlier sessions</button>
     <span id="entry-count"></span>
     <span class="test-buttons">
       <button class="test-btn" data-severity="info" title="Log and notify a test info entry">Test Info</button>

--- a/Dashboards/Log Dashboard/User Interface/index.js
+++ b/Dashboards/Log Dashboard/User Interface/index.js
@@ -17,6 +17,7 @@ class LogDashboardView {
 		this.scriptFilter = document.querySelector('#script-filter');
 		this.sortButton = document.querySelector('#sort-time');
 		this.entryCount = document.querySelector('#entry-count');
+		this.openArchiveButton = document.querySelector('#open-archive');
 		this.toast = document.querySelector('#toast');
 		this.gitStatus = document.querySelector('#git-status');
 		this.testButtons = document.querySelectorAll('.test-btn');
@@ -46,7 +47,7 @@ class LogDashboardView {
 		if (fresh.length === this.entries.length)
 			return;
 
-		const wasCleared = fresh.length < this.entries.length; // e.g. ClearErrorLog() at the next full-suite start
+		const wasCleared = fresh.length < this.entries.length; // e.g. StartNewLogSession() at the next full-suite start
 		this.entries = fresh;
 
 		const previousSeverity = this.severityFilter.value;
@@ -104,6 +105,7 @@ class LogDashboardView {
 			this.sortButton.textContent = `Time ${this.sortDescending ? '↓' : '↑'}`;
 			this._renderRows();
 		});
+		this.openArchiveButton.addEventListener('click', () => AhkDataService.OpenLogArchive());
 		this.testButtons.forEach(button => {
 			button.addEventListener('click', () => {
 				AhkDataService.LogTestMessage(button.dataset.severity);

--- a/Dashboards/Logger/Controller.ahk
+++ b/Dashboards/Logger/Controller.ahk
@@ -1,104 +1,88 @@
 #Include ..\..\Lib\Core.ahk
-#Include ..\..\Lib\Core\WebView.ahk
 #Include ..\..\Dashboards\Log Dashboard\Log Dashboard.ahk
 
-Class LoggerPopup extends WebViewToo {
+; The resident notification host uses a native GUI. The full dashboard remains
+; WebView-based and starts only when requested.
+Class LoggerPopup {
 	static WIN_TITLE := "AutoHotkey Logger"
 	static WIDTH := 290
-	static HEIGHT := 230
 	static MIN_HEIGHT := 34
-	static MARING := 7
-	static Y_POS_MARGIN := 50 + LoggerPopup.MARING ; Taskbar height + margin
-	static VISIBLE_DURATION := 5000 ; ms a severity's detail stays expanded since its last log
+	static MARGIN := 7
+	static Y_POS_MARGIN := 50 + LoggerPopup.MARGIN
+	static VISIBLE_DURATION := 5000
 	static SEVERITIES := ["info", "warning", "error"]
+	static COLORS := Map("info", "3794FF", "warning", "FF9800", "error", "F14C4C")
+	static LABELS := Map("info", ["Info", "Infos"], "warning", ["Warning", "Warnings"], "error", ["Error", "Errors"])
 
 	counts := Map("info", 0, "warning", 0, "error", 0)
 	lastEntryCount := 0
 	isOpen := false
-	currentHeight := LoggerPopup.HEIGHT
 	activeSeverities := Map("info", false, "warning", false, "error", false)
 	hideTimerFns := Map()
+	rows := Map()
 
 	__New() {
-		TraySetIcon "..\..\Lib\icon.png"
-		super.__New()
-		this.Gui.Title := LoggerPopup.WIN_TITLE
-		this.Gui.Opt("+AlwaysOnTop +ToolWindow -SysMenu")
-		this.SetVirtualHostNameToFolderMapping("app.local", Paths.dashboards "\Logger\User Interface", 0) ; block cors error, allow loading local files
-		this.Load("http://app.local/index.html")
-		this.AddCallbackToScript("Dismiss", (*) => this.Dismiss())
-		this.AddCallbackToScript("OpenDashboard", (*) => this.OpenDashboard())
-		this.AddCallbackToScript("Resize", (webview, height) => this.ResizeToContent(height))
+		this.Gui := Gui("+AlwaysOnTop +ToolWindow -SysMenu -Caption", LoggerPopup.WIN_TITLE)
+		this.Gui.BackColor := "1E1E1E"
+		this.Gui.MarginX := 10
+		this.Gui.MarginY := 8
+		this.Gui.SetFont("s9 c0B6623", "Segoe UI")
+		header := this.Gui.AddText("x10 y8 w270 h18", "AutoHotkey")
+		this._BindControl(header)
 
-		for severity in LoggerPopup.SEVERITIES {
+		y := 30
+		for severity in ["error", "warning", "info"] {
+			this.Gui.SetFont("s8 c" LoggerPopup.COLORS[severity], "Segoe UI")
+			label := this.Gui.AddText("x10 y" y " w270 h20 Hidden", "")
+			this.Gui.SetFont("s7 c888888", "Segoe UI")
+			script := this.Gui.AddText("x26 y" (y + 20) " w250 h16 Hidden", "")
+			this.Gui.SetFont("s7 cDDDDDD", "Segoe UI")
+			message := this.Gui.AddText("x26 y" (y + 36) " w250 h18 Hidden", "")
+			for control in [label, script, message]
+				this._BindControl(control)
+			this.rows[severity] := Map("label", label, "script", script, "message", message)
+			y += 56
 			this.hideTimerFns[severity] := this._OnSeverityTimeout.Bind(this, severity)
 		}
 
+		this.Gui.OnEvent("ContextMenu", (*) => this.Dismiss())
 		this.InitializeHidden()
-		this.NavigationCompleted((*) => this._OnPageReady())
-		
-	}
-
-	; Don't start polling until the page has actually finished loading -
-	; window.updateCounts/expandRow don't exist before then, so an
-	; ExecuteScript() call that races the navigation fails silently and
-	; is never retried. That's not just _Seed()'s initial push: _Poll()
-	; itself could win that same race on its very first tick if something
-	; gets logged within the first moment after construction, which is
-	; exactly what happens at startup - leaving the popup stuck showing
-	; the page's default 0/0/0 until an unrelated later log event
-	; happened to succeed. Deferring the whole poll loop, not just the
-	; first push, closes the race for every ExecuteScript call, not just this one.
-
-	; Poll once immediately instead of only pushing counts - a periodic
-	; SetTimer's first tick doesn't fire until its full interval has elapsed,
-	; which would leave any severity already unread at startup (e.g. warnings
-	; logged before this host even started) sitting un-expanded for a second
-	; for no reason. Polling now expands those rows the moment the page can
-	; actually render them.
-	_OnPageReady() {
 		this._Seed()
 		this._Poll()
 		SetTimer(this._Poll.Bind(this), 1000)
 	}
 
-	; Positioned near the tray (bottom-right), shown without stealing focus.
+	_BindControl(control) => control.OnEvent("Click", (*) => this.OpenDashboard())
+
 	Show() {
-		x := A_ScreenWidth - LoggerPopup.WIDTH - LoggerPopup.MARING
-		y := A_ScreenHeight - this.currentHeight - LoggerPopup.Y_POS_MARGIN
-		super.Show(Format("x{} y{} w{} h{} NoActivate", x, y, LoggerPopup.WIDTH, this.currentHeight), LoggerPopup.WIN_TITLE)
+		height := this._Render()
+		x := A_ScreenWidth - LoggerPopup.WIDTH - LoggerPopup.MARGIN
+		y := A_ScreenHeight - height - LoggerPopup.Y_POS_MARGIN
+		this.Gui.Show(Format("x{} y{} w{} h{} NoActivate", x, y, LoggerPopup.WIDTH, height))
 		this.isOpen := true
 	}
 
-	; NoActivate must be omitted here - combined with Hide, AHK's Gui.Show()
-	; treats NoActivate as the show-state and ends up showing the window
-	; (just without activating it) instead of hiding it.
-	InitializeHidden() {
-		x := A_ScreenWidth - LoggerPopup.WIDTH - LoggerPopup.MARING
-		y := A_ScreenHeight - LoggerPopup.HEIGHT - LoggerPopup.Y_POS_MARGIN
-		super.Show(Format("Hide x{} y{} w{} h{}", x, y, LoggerPopup.WIDTH, LoggerPopup.HEIGHT), LoggerPopup.WIN_TITLE)
+	Hide() {
+		this.Gui.Hide()
 		this.isOpen := false
 	}
 
-	ResizeToContent(height) {
-		this.currentHeight := Max(LoggerPopup.MIN_HEIGHT, Round(height))
-		x := A_ScreenWidth - LoggerPopup.WIDTH - LoggerPopup.MARING
-		y := A_ScreenHeight - this.currentHeight - LoggerPopup.Y_POS_MARGIN
-		this.Gui.Move(x, y, LoggerPopup.WIDTH, this.currentHeight)
+	InitializeHidden() {
+		x := A_ScreenWidth - LoggerPopup.WIDTH - LoggerPopup.MARGIN
+		y := A_ScreenHeight - LoggerPopup.MIN_HEIGHT - LoggerPopup.Y_POS_MARGIN
+		this.Gui.Show(Format("Hide x{} y{} w{} h{}", x, y, LoggerPopup.WIDTH, LoggerPopup.MIN_HEIGHT))
+		this.isOpen := false
 	}
 
-	; Dismiss cancels every severity's timer - a right-click closes it outright,
-	; rather than leaving a timer running that would silently reopen it.
 	Dismiss() {
 		MarkAllLogsRead()
 		for severity in LoggerPopup.SEVERITIES {
 			SetTimer(this.hideTimerFns[severity], 0)
 			this.activeSeverities[severity] := false
 		}
-		this.Hide()
-		this.isOpen := false
 		this.counts := Map("info", 0, "warning", 0, "error", 0)
-		this._PushState()
+		this._Render()
+		this.Hide()
 	}
 
 	OpenDashboard() {
@@ -106,93 +90,100 @@ Class LoggerPopup extends WebViewToo {
 		ShowLogDashboard()
 	}
 
-	; Restore unread totals if the logger host is restarted during a session.
-	; lastEntryCount starts at the *read* count, not the total - any entries
-	; still unread (e.g. warnings/errors logged during startup, before this
-	; host even started) must look "new" to the first _Poll() tick so their
-	; row actually expands, instead of just being silently counted.
 	_Seed() {
-		entries := this._ReadAllEntries()
+		entries := ReadLogEntries()
 		this._RefreshUnreadCounts(entries)
 		this.lastEntryCount := Min(GetReadLogEntryCount(), entries.Length)
 	}
 
-	_ReadAllEntries() {
-		return ReadLogEntries()
-	}
-
-	_Count(entry) {
-		severity := entry.Has("severity") ? entry["severity"] : "info"
-		if !this.counts.Has(severity)
-			this.counts[severity] := 0
-		this.counts[severity] += 1
-	}
+	_ReadAllEntries() => ReadLogEntries()
 
 	_RefreshUnreadCounts(entries) {
-		this.counts := GetUnreadLogCounts()
+		this.counts := GetUnreadLogCounts(entries)
 	}
 
 	_Poll() {
 		entries := this._ReadAllEntries()
-
-		if (entries.Length < this.lastEntryCount) {
-			; Logs\errors.log was cleared/rotated (e.g. RunStartup's ClearErrorLog) - start fresh.
+		if (entries.Length < this.lastEntryCount)
 			this.lastEntryCount := 0
-		}
 
 		loop entries.Length - this.lastEntryCount {
 			entry := entries[this.lastEntryCount + A_Index]
-			if (entry.Has("notify") && entry["notify"]) {
-				severity := entry.Has("severity") ? entry["severity"] : "info"
-				this._ShowSeverity(severity, entry)
-			}
+			if (entry.Has("notify") && entry["notify"])
+				this._ShowSeverity(entry.Get("severity", "info"), entry)
 		}
 		this.lastEntryCount := entries.Length
 
 		this._RefreshUnreadCounts(entries)
 		if (GetReadLogEntryCount() >= entries.Length)
 			this._HideNotification()
-		this._PushState()
+		else
+			this._Render()
+	}
+
+	_ShowSeverity(severity, entry) {
+		if !this.rows.Has(severity)
+			return
+		this.activeSeverities[severity] := true
+		this.rows[severity]["script"].Text := entry.Get("script", "")
+		this.rows[severity]["message"].Text := entry.Get("message", "")
+		this.Show()
+		SetTimer(this.hideTimerFns[severity], 0)
+		SetTimer(this.hideTimerFns[severity], -LoggerPopup.VISIBLE_DURATION)
 	}
 
 	_HideNotification() {
 		for severity in LoggerPopup.SEVERITIES {
 			SetTimer(this.hideTimerFns[severity], 0)
 			this.activeSeverities[severity] := false
-			this.ExecuteScript("window.collapseRow('" severity "')")
 		}
+		this._Render()
 		this.Hide()
-		this.isOpen := false
 	}
 
-	; Expands (or re-expands) one severity's row with its latest entry, opens
-	; the popup if it was closed, and (re)starts that severity's own 5s timer.
-	_ShowSeverity(severity, entry) {
-		this.activeSeverities[severity] := true
-		this.Show()
-
-		payload := Map(
-			"script", entry.Has("script") ? entry["script"] : "",
-			"message", entry.Has("message") ? entry["message"] : ""
-		)
-		this.ExecuteScript("window.expandRow('" severity "', " JSON.Dump(payload) ")")
-
-		SetTimer(this.hideTimerFns[severity], 0) ; cancel any pending hide for this severity
-		SetTimer(this.hideTimerFns[severity], -LoggerPopup.VISIBLE_DURATION) ; ...and restart it
-	}
-
-	; Fires 5s after the last log for this severity. Keep every displayed detail
-	; expanded until the final severity timer has expired, then close them all.
 	_OnSeverityTimeout(severity) {
 		this.activeSeverities[severity] := false
-
-		for sev in LoggerPopup.SEVERITIES {
-			if this.activeSeverities[sev]
+		for otherSeverity in LoggerPopup.SEVERITIES {
+			if this.activeSeverities[otherSeverity] {
+				this._Render()
 				return
+			}
 		}
-
 		this._HideNotification()
 	}
 
-	_PushState() => this.ExecuteScript("window.updateCounts(" JSON.Dump(this.counts) ")")
+	_Render() {
+		y := 30
+		for severity in ["error", "warning", "info"] {
+			row := this.rows[severity]
+			count := this.counts.Get(severity, 0)
+			visible := count > 0
+			labels := LoggerPopup.LABELS[severity]
+			row["label"].Text := "●  " count " " labels[count = 1 ? 1 : 2]
+			row["label"].Visible := visible
+			if !visible {
+				row["script"].Visible := false
+				row["message"].Visible := false
+				continue
+			}
+
+			row["label"].Move(10, y, 270, 20)
+			y += 20
+			expanded := this.activeSeverities[severity]
+			row["script"].Visible := expanded
+			row["message"].Visible := expanded
+			if expanded {
+				row["script"].Move(26, y, 250, 16)
+				row["message"].Move(26, y + 16, 250, 18)
+				y += 36
+			}
+		}
+		height := Max(LoggerPopup.MIN_HEIGHT, y + 4)
+		if this.isOpen {
+			x := A_ScreenWidth - LoggerPopup.WIDTH - LoggerPopup.MARGIN
+			windowY := A_ScreenHeight - height - LoggerPopup.Y_POS_MARGIN
+			this.Gui.Move(x, windowY, LoggerPopup.WIDTH, height)
+		}
+		return height
+	}
 }

--- a/Dashboards/Logger/Controller.ahk
+++ b/Dashboards/Logger/Controller.ahk
@@ -16,6 +16,7 @@ Class LoggerPopup {
 
 	counts := Map("info", 0, "warning", 0, "error", 0)
 	lastEntryCount := 0
+	logSessionId := ""
 	isOpen := false
 	activeSeverities := Map("info", false, "warning", false, "error", false)
 	hideTimerFns := Map()
@@ -94,6 +95,7 @@ Class LoggerPopup {
 		entries := ReadLogEntries()
 		this._RefreshUnreadCounts(entries)
 		this.lastEntryCount := Min(GetReadLogEntryCount(), entries.Length)
+		this.logSessionId := GetLogSessionId()
 	}
 
 	_ReadAllEntries() => ReadLogEntries()
@@ -104,8 +106,14 @@ Class LoggerPopup {
 
 	_Poll() {
 		entries := this._ReadAllEntries()
-		if (entries.Length < this.lastEntryCount)
+		currentSessionId := GetLogSessionId()
+		if (currentSessionId != this.logSessionId) {
 			this.lastEntryCount := 0
+			this.logSessionId := currentSessionId
+		} else if (entries.Length < this.lastEntryCount) {
+			; Retain a defensive fallback for external/manual log truncation.
+			this.lastEntryCount := 0
+		}
 
 		loop entries.Length - this.lastEntryCount {
 			entry := entries[this.lastEntryCount + A_Index]

--- a/Dashboards/Logger/Controller.ahk
+++ b/Dashboards/Logger/Controller.ahk
@@ -92,21 +92,21 @@ Class LoggerPopup {
 	}
 
 	_Seed() {
-		entries := ReadLogEntries()
-		this._RefreshUnreadCounts(entries)
-		this.lastEntryCount := Min(GetReadLogEntryCount(), entries.Length)
-		this.logSessionId := GetLogSessionId()
+		state := ReadLogState()
+		entries := state["entries"]
+		this._RefreshUnreadCounts(entries, state["readEntryCount"])
+		this.lastEntryCount := Min(state["readEntryCount"], entries.Length)
+		this.logSessionId := state["sessionId"]
 	}
 
-	_ReadAllEntries() => ReadLogEntries()
-
-	_RefreshUnreadCounts(entries) {
-		this.counts := GetUnreadLogCounts(entries)
+	_RefreshUnreadCounts(entries, readEntryCount) {
+		this.counts := GetUnreadLogCounts(entries, readEntryCount)
 	}
 
 	_Poll() {
-		entries := this._ReadAllEntries()
-		currentSessionId := GetLogSessionId()
+		state := ReadLogState()
+		entries := state["entries"]
+		currentSessionId := state["sessionId"]
 		if (currentSessionId != this.logSessionId) {
 			this.lastEntryCount := 0
 			this.logSessionId := currentSessionId
@@ -122,8 +122,8 @@ Class LoggerPopup {
 		}
 		this.lastEntryCount := entries.Length
 
-		this._RefreshUnreadCounts(entries)
-		if (GetReadLogEntryCount() >= entries.Length)
+		this._RefreshUnreadCounts(entries, state["readEntryCount"])
+		if (state["readEntryCount"] >= entries.Length)
 			this._HideNotification()
 		else
 			this._Render()

--- a/Dashboards/Logger/Controller.ahk
+++ b/Dashboards/Logger/Controller.ahk
@@ -34,23 +34,31 @@ Class LoggerPopup extends WebViewToo {
 			this.hideTimerFns[severity] := this._OnSeverityTimeout.Bind(this, severity)
 		}
 
-		this._Seed()
 		this.InitializeHidden()
-		; Don't start polling until the page has actually finished loading -
-		; window.updateCounts/expandRow don't exist before then, so an
-		; ExecuteScript() call that races the navigation fails silently and
-		; is never retried. That's not just _Seed()'s initial push: _Poll()
-		; itself could win that same race on its very first tick if something
-		; gets logged within the first moment after construction, which is
-		; exactly what happens at startup - leaving the popup stuck showing
-		; the page's default 0/0/0 until an unrelated later log event
-		; happened to succeed. Deferring the whole poll loop, not just the
-		; first push, closes the race for every ExecuteScript call, not just this one.
 		this.NavigationCompleted((*) => this._OnPageReady())
+		
 	}
 
+	; Don't start polling until the page has actually finished loading -
+	; window.updateCounts/expandRow don't exist before then, so an
+	; ExecuteScript() call that races the navigation fails silently and
+	; is never retried. That's not just _Seed()'s initial push: _Poll()
+	; itself could win that same race on its very first tick if something
+	; gets logged within the first moment after construction, which is
+	; exactly what happens at startup - leaving the popup stuck showing
+	; the page's default 0/0/0 until an unrelated later log event
+	; happened to succeed. Deferring the whole poll loop, not just the
+	; first push, closes the race for every ExecuteScript call, not just this one.
+
+	; Poll once immediately instead of only pushing counts - a periodic
+	; SetTimer's first tick doesn't fire until its full interval has elapsed,
+	; which would leave any severity already unread at startup (e.g. warnings
+	; logged before this host even started) sitting un-expanded for a second
+	; for no reason. Polling now expands those rows the moment the page can
+	; actually render them.
 	_OnPageReady() {
-		this._PushState()
+		this._Seed()
+		this._Poll()
 		SetTimer(this._Poll.Bind(this), 1000)
 	}
 
@@ -99,10 +107,14 @@ Class LoggerPopup extends WebViewToo {
 	}
 
 	; Restore unread totals if the logger host is restarted during a session.
+	; lastEntryCount starts at the *read* count, not the total - any entries
+	; still unread (e.g. warnings/errors logged during startup, before this
+	; host even started) must look "new" to the first _Poll() tick so their
+	; row actually expands, instead of just being silently counted.
 	_Seed() {
 		entries := this._ReadAllEntries()
 		this._RefreshUnreadCounts(entries)
-		this.lastEntryCount := entries.Length
+		this.lastEntryCount := Min(GetReadLogEntryCount(), entries.Length)
 	}
 
 	_ReadAllEntries() {

--- a/Dashboards/Logger/Controller.ahk
+++ b/Dashboards/Logger/Controller.ahk
@@ -46,8 +46,7 @@ Class LoggerPopup extends WebViewToo {
 		; the page's default 0/0/0 until an unrelated later log event
 		; happened to succeed. Deferring the whole poll loop, not just the
 		; first push, closes the race for every ExecuteScript call, not just this one.
-		this._PushState()
-		SetTimer(this._Poll.Bind(this), 1000)
+		this.NavigationCompleted((*) => this._OnPageReady())
 	}
 
 	_OnPageReady() {

--- a/Dashboards/Logger/Logger.ahk
+++ b/Dashboards/Logger/Logger.ahk
@@ -5,7 +5,7 @@
 ; [FEATURES]
 ;   - Uses a lightweight native AHK GUI (no resident WebView2 process)
 ;   - Polls Logs\errors.log for new entries (no cross-process messaging needed)
-;   - Shows a small always-on-top popup 5 seconds after the last log entry
+;   - Shows notifying entries immediately, then hides 5 seconds after the latest
 ;   - Collapsed rows for info/warning/error with running counts; the row for
 ;     the latest not-yet-seen entry expands to show its script + message
 ;   - Left-click opens the Log Dashboard; right-click dismisses the popup
@@ -43,8 +43,7 @@ FindLoggerWindow() {
 
 StartLogger() => Run('"' A_AhkPath '" "' Paths.dashboards '\Logger\Logger Host.ahk"')
 
-; A generous timeout - WebView2 first-run init (extracting the loader, spinning
-; up its child process) can take several seconds on a cold/slow machine.
+; Leave enough time for a cold machine or security scanner to start the host.
 WaitForLoggerWindow(timeoutMs := 20000) {
 	startedAt := A_TickCount
 	while (A_TickCount - startedAt < timeoutMs) {

--- a/Dashboards/Logger/Logger.ahk
+++ b/Dashboards/Logger/Logger.ahk
@@ -3,6 +3,7 @@
 ; ============================================================================
 ;
 ; [FEATURES]
+;   - Uses a lightweight native AHK GUI (no resident WebView2 process)
 ;   - Polls Logs\errors.log for new entries (no cross-process messaging needed)
 ;   - Shows a small always-on-top popup 5 seconds after the last log entry
 ;   - Collapsed rows for info/warning/error with running counts; the row for

--- a/Dashboards/Logger/Logging.ahk
+++ b/Dashboards/Logger/Logging.ahk
@@ -11,8 +11,6 @@
 #Include ..\Log Dashboard\Log Dashboard.ahk
 
 InitializeLogging() {
-	ClearErrorLog()
-
 	; Both host scripts use #SingleInstance Force. Starting them here replaces
 	; instances left over from an earlier startup with fresh session-owned hosts.
 	StartLogger()

--- a/Dashboards/Logger/Logging.ahk
+++ b/Dashboards/Logger/Logging.ahk
@@ -11,15 +11,18 @@
 #Include ..\Log Dashboard\Log Dashboard.ahk
 
 InitializeLogging() {
-	; Both host scripts use #SingleInstance Force. Starting them here replaces
-	; instances left over from an earlier startup with fresh session-owned hosts.
+	return Map("logger", EnsureLoggerRunning())
+}
+
+; The popup is the only logging UI that must stay resident. Reuse an existing
+; host across suite reloads; the dashboard starts lazily from ShowLogDashboard().
+EnsureLoggerRunning() {
+	if loggerWindow := FindLoggerWindow()
+		return loggerWindow
+
 	StartLogger()
-	loggerWindow := WaitForLoggerWindow()
-	StartLogDashboard()
-	dashboardWindow := WaitForLogDashboardWindow()
+	if loggerWindow := WaitForLoggerWindow()
+		return loggerWindow
 
-	if !dashboardWindow || !loggerWindow
-		throw Error("Failed to initialize logger UI hosts (logger=" loggerWindow ", dashboard=" dashboardWindow ")")
-
-	return Map("dashboard", dashboardWindow, "logger", loggerWindow)
+	throw Error("Failed to initialize the Logger host")
 }

--- a/Lib/Core/OnError.ahk
+++ b/Lib/Core/OnError.ahk
@@ -4,23 +4,53 @@
 OnError(HandleUnhandledError)
 
 HandleUnhandledError(error, mode) {
-    try LogAndNotifyError(error.Message, error.HasProp("Stack") ? error.Stack : "")
-    return true ; Suppress the default modal error dialog; the failed thread ends.
+    try {
+        LogAndNotifyError(error.Message, error.HasProp("Stack") ? error.Stack : "")
+        return true ; Suppress the default dialog only after persistence succeeds.
+    }
+    return false ; Preserve AutoHotkey's fallback when the logging path itself fails.
 }
 
 ErrorLogDirectory() => EnvGet("AUTOHOTKEY_LOG_DIR") != "" ? EnvGet("AUTOHOTKEY_LOG_DIR") : Paths.autohotkey "\Logs"
 ErrorLogFile() => ErrorLogDirectory() "\errors.log"
 ErrorLogReadStateFile() => ErrorLogDirectory() "\errors.read"
+ErrorLogArchiveDirectory() => ErrorLogDirectory() "\Archive"
+
+; Every AHK process writes the same two files. A named mutex keeps append,
+; read-cursor updates, and session reset/rotation atomic across processes.
+LoggingMutexName() => "Local\AutoHotkeySuite.StructuredLogging"
+
+WithLoggingLock(callback, timeoutMs := 15000) {
+	mutex := DllCall("CreateMutexW", "Ptr", 0, "Int", false, "Str", LoggingMutexName(), "Ptr")
+	if !mutex
+		throw OSError()
+	waitResult := DllCall("WaitForSingleObject", "Ptr", mutex, "UInt", timeoutMs, "UInt")
+	if (waitResult != 0 && waitResult != 0x80) {
+		DllCall("CloseHandle", "Ptr", mutex)
+		if (waitResult = 0x102)
+			throw Error("Timed out waiting for the shared logging lock")
+		throw OSError()
+	}
+	try return callback.Call()
+	finally {
+		DllCall("ReleaseMutex", "Ptr", mutex)
+		DllCall("CloseHandle", "Ptr", mutex)
+	}
+}
 
 GetLogEntryCount() {
 	return ReadLogEntries().Length
 }
 
 ReadLogEntries() {
+	return ReadLogEntriesFromFile(ErrorLogFile())
+}
+
+ReadLogEntriesFromFile(logFile) {
 	entries := []
-	if !FileExist(ErrorLogFile())
+	if !FileExist(logFile)
 		return entries
-	for line in StrSplit(FileRead(ErrorLogFile(), "UTF-8"), "`n", "`r") {
+	for line in StrSplit(FileRead(logFile, "UTF-8"), "`n", "`r") {
 		if (Trim(line) = "")
 			continue
 		try {
@@ -40,14 +70,19 @@ GetReadLogEntryCount() {
 }
 
 MarkAllLogsRead() {
-	DirCreate(ErrorLogDirectory())
-    readState := FileOpen(ErrorLogReadStateFile(), "w", "UTF-8")
-    readState.Write(GetLogEntryCount())
-	readState.Close()
+	WithLoggingLock(() => _MarkAllLogsReadLocked())
 }
 
-GetUnreadLogEntries() {
-	entries := ReadLogEntries()
+_MarkAllLogsReadLocked() {
+	DirCreate(ErrorLogDirectory())
+	readState := FileOpen(ErrorLogReadStateFile(), "w", "UTF-8")
+	try readState.Write(GetLogEntryCount())
+	finally readState.Close()
+}
+
+GetUnreadLogEntries(entries?) {
+	if !IsSet(entries)
+		entries := ReadLogEntries()
 	readEntryCount := Min(GetReadLogEntryCount(), entries.Length)
 	unreadEntries := []
 	loop entries.Length - readEntryCount
@@ -55,9 +90,10 @@ GetUnreadLogEntries() {
 	return unreadEntries
 }
 
-GetUnreadLogCounts() {
+GetUnreadLogCounts(entries?) {
 	counts := Map("info", 0, "warning", 0, "error", 0)
-	for entry in GetUnreadLogEntries() {
+	unreadEntries := IsSet(entries) ? GetUnreadLogEntries(entries) : GetUnreadLogEntries()
+	for entry in unreadEntries {
 		severity := entry.Has("severity") ? entry["severity"] : "info"
 		if counts.Has(severity)
 			counts[severity] += 1
@@ -81,6 +117,8 @@ LogAndNotifyError(message, stack := "") => AppendLogEntry("error", message, stac
 ; so past errors stay reviewable instead of only flashing in a toast.
 ; `notify` marks entries the Logger popup should surface, not just count.
 AppendLogEntry(severity, message, stack := "", notify := false) {
+	if !(stack is String)
+		throw TypeError("Log entry stack must be a string", -1, Type(stack))
     entry := Map(
         "timestamp", FormatTime(, "yyyy-MM-dd HH:mm:ss"),
         "script", A_ScriptName,
@@ -89,15 +127,60 @@ AppendLogEntry(severity, message, stack := "", notify := false) {
         "stack", stack,
         "notify", notify
     )
-	DirCreate(ErrorLogDirectory())
-    FileAppend(JSON.Dump(entry) "`n", ErrorLogFile(), "UTF-8")
+	serializedEntry := JSON.Dump(entry) "`n"
+	WithLoggingLock(() => _AppendLogEntryLocked(serializedEntry))
 }
 
-; Called once per full-suite start (see RunStartup) so the dashboard only ever
-; shows errors from the current run, not accumulated history from past runs.
+_AppendLogEntryLocked(serializedEntry) {
+	DirCreate(ErrorLogDirectory())
+	FileAppend(serializedEntry, ErrorLogFile(), "UTF-8")
+}
+
+; Test/reset helper. Full-suite startup uses StartNewLogSession() so history is
+; archived instead of discarded.
 ClearErrorLog() {
+	WithLoggingLock(() => _ClearErrorLogLocked())
+}
+
+_ClearErrorLogLocked() {
     if FileExist(ErrorLogFile())
         FileDelete(ErrorLogFile())
     if FileExist(ErrorLogReadStateFile())
         FileDelete(ErrorLogReadStateFile())
+}
+
+StartNewLogSession(maxArchives := 10) {
+	WithLoggingLock(() => _StartNewLogSessionLocked(maxArchives))
+}
+
+_StartNewLogSessionLocked(maxArchives) {
+	DirCreate(ErrorLogDirectory())
+	if (FileExist(ErrorLogFile()) && FileGetSize(ErrorLogFile()) > 0) {
+		DirCreate(ErrorLogArchiveDirectory())
+		baseName := ErrorLogArchiveDirectory() "\errors-" FormatTime(, "yyyyMMdd-HHmmss")
+		archiveIndex := 0
+		loop files baseName "-*.log", "F" {
+			if RegExMatch(A_LoopFileName, "-(\d+)\.log$", &match)
+				archiveIndex := Max(archiveIndex, Integer(match[1]))
+		}
+		archivePath := baseName "-" Format("{:03}", archiveIndex + 1) ".log"
+		FileMove(ErrorLogFile(), archivePath)
+	}
+	if FileExist(ErrorLogReadStateFile())
+		FileDelete(ErrorLogReadStateFile())
+	_PruneLogArchivesLocked(maxArchives)
+}
+
+_PruneLogArchivesLocked(maxArchives) {
+	if !DirExist(ErrorLogArchiveDirectory())
+		return
+	archiveList := ""
+	loop files ErrorLogArchiveDirectory() "\errors-*.log", "F"
+		archiveList .= A_LoopFileFullPath "`n"
+	if !archiveList
+		return
+	archives := StrSplit(RTrim(Sort(archiveList), "`n"), "`n")
+	deleteCount := Max(0, archives.Length - Max(0, maxArchives))
+	loop deleteCount
+		FileDelete(archives[A_Index])
 }

--- a/Lib/Core/OnError.ahk
+++ b/Lib/Core/OnError.ahk
@@ -14,6 +14,7 @@ HandleUnhandledError(error, mode) {
 ErrorLogDirectory() => EnvGet("AUTOHOTKEY_LOG_DIR") != "" ? EnvGet("AUTOHOTKEY_LOG_DIR") : Paths.autohotkey "\Logs"
 ErrorLogFile() => ErrorLogDirectory() "\errors.log"
 ErrorLogReadStateFile() => ErrorLogDirectory() "\errors.read"
+ErrorLogSessionStateFile() => ErrorLogDirectory() "\errors.session"
 ErrorLogArchiveDirectory() => ErrorLogDirectory() "\Archive"
 
 ; Every AHK process writes the same two files. A named mutex keeps append,
@@ -71,6 +72,13 @@ GetReadLogEntryCount() {
 
 MarkAllLogsRead() {
 	WithLoggingLock(() => _MarkAllLogsReadLocked())
+}
+
+GetLogSessionId() {
+	if !FileExist(ErrorLogSessionStateFile())
+		return ""
+	try return Trim(FileRead(ErrorLogSessionStateFile(), "UTF-8"))
+	return ""
 }
 
 _MarkAllLogsReadLocked() {
@@ -143,10 +151,12 @@ ClearErrorLog() {
 }
 
 _ClearErrorLogLocked() {
+	DirCreate(ErrorLogDirectory())
     if FileExist(ErrorLogFile())
         FileDelete(ErrorLogFile())
     if FileExist(ErrorLogReadStateFile())
         FileDelete(ErrorLogReadStateFile())
+	_WriteNewLogSessionIdLocked()
 }
 
 StartNewLogSession(maxArchives := 10) {
@@ -168,7 +178,18 @@ _StartNewLogSessionLocked(maxArchives) {
 	}
 	if FileExist(ErrorLogReadStateFile())
 		FileDelete(ErrorLogReadStateFile())
+	_WriteNewLogSessionIdLocked()
 	_PruneLogArchivesLocked(maxArchives)
+}
+
+_WriteNewLogSessionIdLocked() {
+	static sequence := 0
+	sequence++
+	sessionId := FormatTime(, "yyyyMMdd-HHmmss") "-" DllCall("GetCurrentProcessId") "-" A_TickCount "-" sequence
+	stateFile := FileOpen(ErrorLogSessionStateFile(), "w", "UTF-8")
+	try stateFile.Write(sessionId)
+	finally stateFile.Close()
+	return sessionId
 }
 
 _PruneLogArchivesLocked(maxArchives) {

--- a/Lib/Core/OnError.ahk
+++ b/Lib/Core/OnError.ahk
@@ -44,10 +44,16 @@ GetLogEntryCount() {
 }
 
 ReadLogEntries() {
-	return ReadLogEntriesFromFile(ErrorLogFile())
+	return WithLoggingLock(() => _ReadLogEntriesFromFileLocked(ErrorLogFile()))
 }
 
 ReadLogEntriesFromFile(logFile) {
+	return WithLoggingLock(() => _ReadLogEntriesFromFileLocked(logFile))
+}
+
+; Caller must hold the logging mutex so rotation cannot move the file between
+; the existence check and the read.
+_ReadLogEntriesFromFileLocked(logFile) {
 	entries := []
 	if !FileExist(logFile)
 		return entries
@@ -64,6 +70,10 @@ ReadLogEntriesFromFile(logFile) {
 }
 
 GetReadLogEntryCount() {
+	return WithLoggingLock(() => _GetReadLogEntryCountLocked())
+}
+
+_GetReadLogEntryCountLocked() {
     if !FileExist(ErrorLogReadStateFile())
         return 0
     try return Max(0, Integer(Trim(FileRead(ErrorLogReadStateFile(), "UTF-8"))))
@@ -75,32 +85,54 @@ MarkAllLogsRead() {
 }
 
 GetLogSessionId() {
+	return WithLoggingLock(() => _GetLogSessionIdLocked())
+}
+
+_GetLogSessionIdLocked() {
 	if !FileExist(ErrorLogSessionStateFile())
 		return ""
 	try return Trim(FileRead(ErrorLogSessionStateFile(), "UTF-8"))
 	return ""
 }
 
+; Return one consistent view for consumers that need entries, the read cursor,
+; and the session identity together.
+ReadLogState() {
+	return WithLoggingLock(() => Map(
+		"entries", _ReadLogEntriesFromFileLocked(ErrorLogFile()),
+		"readEntryCount", _GetReadLogEntryCountLocked(),
+		"sessionId", _GetLogSessionIdLocked()
+	))
+}
+
 _MarkAllLogsReadLocked() {
 	DirCreate(ErrorLogDirectory())
 	readState := FileOpen(ErrorLogReadStateFile(), "w", "UTF-8")
-	try readState.Write(GetLogEntryCount())
+	try readState.Write(_ReadLogEntriesFromFileLocked(ErrorLogFile()).Length)
 	finally readState.Close()
 }
 
-GetUnreadLogEntries(entries?) {
-	if !IsSet(entries)
-		entries := ReadLogEntries()
-	readEntryCount := Min(GetReadLogEntryCount(), entries.Length)
+GetUnreadLogEntries(entries?, readEntryCount?) {
+	if !IsSet(entries) {
+		state := ReadLogState()
+		entries := state["entries"]
+		readEntryCount := state["readEntryCount"]
+	} else if !IsSet(readEntryCount) {
+		readEntryCount := GetReadLogEntryCount()
+	}
+	readEntryCount := Min(readEntryCount, entries.Length)
 	unreadEntries := []
 	loop entries.Length - readEntryCount
 		unreadEntries.Push(entries[readEntryCount + A_Index])
 	return unreadEntries
 }
 
-GetUnreadLogCounts(entries?) {
+GetUnreadLogCounts(entries?, readEntryCount?) {
 	counts := Map("info", 0, "warning", 0, "error", 0)
-	unreadEntries := IsSet(entries) ? GetUnreadLogEntries(entries) : GetUnreadLogEntries()
+	if IsSet(entries)
+		unreadEntries := IsSet(readEntryCount) ? GetUnreadLogEntries(entries, readEntryCount) : GetUnreadLogEntries(entries)
+	else
+		unreadEntries := GetUnreadLogEntries()
 	for entry in unreadEntries {
 		severity := entry.Has("severity") ? entry["severity"] : "info"
 		if counts.Has(severity)

--- a/Lib/Tools/WebView/WebViewToo.ahk
+++ b/Lib/Tools/WebView/WebViewToo.ahk
@@ -72,7 +72,12 @@ class WebViewToo {
         this.Gui.BorderSize := 0, this.MaximizedBorderSize := 7
         this.Gui.Add("Button", "x0 y0 vNCLBUTTONDOWN_Sink Hidden", "John Cena")
         this.Gui.Add("Text", "x" this.BorderSize " y" this.BorderSize " vWebViewTooContainer BackgroundTrans", "If you can see this, something went wrong.")
-        this.wvc := !A_IsCompiled ? WebView2.create(this.Gui["WebViewTooContainer"].Hwnd) : WebView2.create(this.Gui["WebViewTooContainer"].Hwnd,,,,,, WebViewToo.DllPath)
+        ; Each host gets its own WebView2 profile. Sharing Edge's browser profile
+        ; can fail when Edge or another AHK dashboard already holds it open.
+        userDataDir := WebViewToo.TempDir "\User Data-" DllCall("GetCurrentProcessId")
+        this.wvc := !A_IsCompiled
+            ? WebView2.create(this.Gui["WebViewTooContainer"].Hwnd,,, userDataDir)
+            : WebView2.create(this.Gui["WebViewTooContainer"].Hwnd,,, userDataDir,,, WebViewToo.DllPath)
         this.IsVisible := 1, this.wv := this.wvc.CoreWebView2
         this.Gui.OnEvent("Size", (*) => this.Fill())
         this.AddCallbackToScript("Close", this.Close)

--- a/Profiles/Profile Manager.ahk
+++ b/Profiles/Profile Manager.ahk
@@ -24,23 +24,10 @@ Class Profile {
 }
 
 Class Profiles {
-    ; Static field initializers run top-to-bottom the moment this class is
-    ; defined (auto-execute, in every process that includes this file) - if
-    ; Secrets.WorkDeviceNames.Get() ever throws, every field below "work"
-    ; (including "default") never gets assigned, and anything reading
-    ; Profiles.default (ProfileManager.current's own initializer) then fails
-    ; too. Guard this one lookup so a broken secrets file can't take out the
-    ; rest of the class.
-    static work := Profile("Work", Profiles._SafeWorkDeviceNames())
+    static work := Profile("Work", Secrets.WorkDeviceNames.Get())
     static devbox := Profile("Dev Box", ["DESKTOP-2NC1KCL", "CPC-fbrem-HLWU3"]) ; [VM, Dev Box]
     static woonkamerLaptops := Profile("Woonkamer Laptops", ["FLOPLAPTOP", "LAPTOP-LNTJIJKB"]) ; [Amyrion, Magneet]
     static default := Profile("Default", "")
-
-    static _SafeWorkDeviceNames() {
-        try return Secrets.WorkDeviceNames.Get()
-        catch
-            return ""
-    }
 }
 
 Class ProfileManager {

--- a/Profiles/Profile Manager.ahk
+++ b/Profiles/Profile Manager.ahk
@@ -24,10 +24,23 @@ Class Profile {
 }
 
 Class Profiles {
-    static work := Profile("Work", Secrets.WorkDeviceNames.Get())
+    ; Static field initializers run top-to-bottom the moment this class is
+    ; defined (auto-execute, in every process that includes this file) - if
+    ; Secrets.WorkDeviceNames.Get() ever throws, every field below "work"
+    ; (including "default") never gets assigned, and anything reading
+    ; Profiles.default (ProfileManager.current's own initializer) then fails
+    ; too. Guard this one lookup so a broken secrets file can't take out the
+    ; rest of the class.
+    static work := Profile("Work", Profiles._SafeWorkDeviceNames())
     static devbox := Profile("Dev Box", ["DESKTOP-2NC1KCL", "CPC-fbrem-HLWU3"]) ; [VM, Dev Box]
     static woonkamerLaptops := Profile("Woonkamer Laptops", ["FLOPLAPTOP", "LAPTOP-LNTJIJKB"]) ; [Amyrion, Magneet]
     static default := Profile("Default", "")
+
+    static _SafeWorkDeviceNames() {
+        try return Secrets.WorkDeviceNames.Get()
+        catch
+            return ""
+    }
 }
 
 Class ProfileManager {

--- a/Secrets/Secret.ahk
+++ b/Secrets/Secret.ahk
@@ -42,7 +42,9 @@ class Secret {
             SecretsFileManager.Initialize()
             return true
         } catch as initError {
-            LogAndNotifyError("Secret '" . this.name . "' unavailable - the secrets file failed to load: " . initError.Message,
+            ; Never let reporting the failure become a second failure - Get()/
+            ; GetOrSet() must always return a value, not throw.
+            try LogAndNotifyError("Secret '" . this.name . "' unavailable - the secrets file failed to load: " . initError.Message,
                 initError.HasProp("Stack") ? initError.Stack : "")
             return false
         }

--- a/Secrets/Secret.ahk
+++ b/Secrets/Secret.ahk
@@ -8,16 +8,18 @@ class Secret {
 
     ; Retrieve the secret value (may be empty)
     Get() {
-        SecretsFileManager.Initialize()
+        if !this._TryInitialize()
+            return ""
         if this._value = ""
             LogAndNotifyWarning("Secret not found: " . this.name)
 
         return this._value
     }
 
-    ; Retrieve the secret value, if not set prompt the user to store it 
+    ; Retrieve the secret value, if not set prompt the user to store it
     GetOrSet() {
-        SecretsFileManager.Initialize()
+        if !this._TryInitialize()
+            return ""
         if this._value != ""
             return this._value
 
@@ -27,6 +29,23 @@ class Secret {
             SecretsFileManager.UpdateExistingSecret(this)
 
         return this._value
+    }
+
+    ; Every secret access routes through SecretsFileManager.Initialize(), which
+    ; throws when the secrets file is broken (e.g. invalid JSON). Left
+    ; uncaught, that exception surfaces from whatever script happened to touch
+    ; a secret first - usually far away from Startup.ahk, in a process whose
+    ; own OnError handler only logs quietly. Surface it here instead, once per
+    ; secret access, so the caller sees a clear reason the value came back empty.
+    _TryInitialize() {
+        try {
+            SecretsFileManager.Initialize()
+            return true
+        } catch as initError {
+            LogAndNotifyError("Secret '" . this.name . "' unavailable - the secrets file failed to load: " . initError.Message,
+                initError.HasProp("Stack") ? initError.Stack : "")
+            return false
+        }
     }
 
     ; Send() => ClipSend(this.GetOrSet()) sleep(100) Send("{BackSpace}") ; Remove space added by ClipSend

--- a/Secrets/Secrets File Manager.ahk
+++ b/Secrets/Secrets File Manager.ahk
@@ -7,14 +7,25 @@ class SecretsFileManager {
     static MUTEX_NAME := "Local\AutoHotkey.SecretsFileManager"
     static MUTEX_TIMEOUT_MS := 10000
     static _initialized := false
+    static _initError := ""
 
     ; Load all values once, create the local file, and add newly required keys.
+    ; Every secret ends up routing through here (Secret.Get/GetOrSet call it on
+    ; every access), so a broken secrets file must fail fast and consistently:
+    ; cache the failure instead of re-parsing and re-throwing on every access.
     static Initialize(force := false) {
         if this._initialized && !force
             return
+        if this._initError && !force
+            throw this._initError
 
         ; Synchronization is a read-modify-write operation shared by all AHK processes.
-        return this._WithFileLock(() => this._Initialize(force))
+        try {
+            return this._WithFileLock(() => this._Initialize(force))
+        } catch as initError {
+            this._initError := initError
+            throw initError
+        }
     }
 
     ; Synchronize in-memory secrets, active values, removed values, and catalog definitions.
@@ -91,6 +102,7 @@ class SecretsFileManager {
             this._WriteJsonFile(this.REMOVED_FILE_PATH, removedSecrets)
 
         this._initialized := true
+        this._initError := ""
     }
 
     ; Lock the complete read-modify-write cycle so concurrent updates cannot overwrite each other.

--- a/Secrets/Secrets File Manager.ahk
+++ b/Secrets/Secrets File Manager.ahk
@@ -36,21 +36,21 @@ class SecretsFileManager {
             displayNames[secretDefinition.name] := true
             secretDefinition.key := propertyName
 
-            if secrets.Has(propertyName) && Type(secrets[propertyName]) = "String" {
+            if secrets.Has(propertyName) && this._IsValidSecretValue(secrets[propertyName]) {
                 secretDefinition._value := secrets[propertyName]
                 ; An active catalog entry must not also remain in the archive.
                 if removedSecrets.Has(propertyName) {
                     removedSecrets.Delete(propertyName)
                     removedFileNeedsUpdate := true
                 }
-            } else if removedSecrets.Has(propertyName) && Type(removedSecrets[propertyName]) = "String" {
+            } else if removedSecrets.Has(propertyName) && this._IsValidSecretValue(removedSecrets[propertyName]) {
                 ; Restore a preserved value when a removed catalog key is reintroduced.
                 secretDefinition._value := removedSecrets[propertyName]
                 secrets[propertyName] := secretDefinition._value
                 removedSecrets.Delete(propertyName)
                 fileNeedsUpdate := true
                 removedFileNeedsUpdate := true
-            } else if secrets.Has(secretDefinition.name) && Type(secrets[secretDefinition.name]) = "String" {
+            } else if secrets.Has(secretDefinition.name) && this._IsValidSecretValue(secrets[secretDefinition.name]) {
                 ; Migrate files created by the earlier display-name-keyed format.
                 secretDefinition._value := secrets[secretDefinition.name]
                 secrets[propertyName] := secretDefinition._value
@@ -112,9 +112,21 @@ class SecretsFileManager {
         return true
     }
 
+    ; A secret value is either a plain string, or an array of strings.
+    static _IsValidSecretValue(value) {
+        if Type(value) = "String"
+            return true
+        if Type(value) != "Array"
+            return false
+        for item in value
+            if Type(item) != "String"
+                return false
+        return true
+    }
+
     ; Read the active local secrets file.
     static _ReadSecrets() => this._ReadJsonFile(this.FILE_PATH)
-    
+
 
     ; Read and validate a secrets JSON file, returning an empty map when it does not exist.
     static _ReadJsonFile(filePath) {
@@ -143,9 +155,10 @@ class SecretsFileManager {
         return values
     }
 
-    ; Check that JSON follows the supported string-key/string-value object format.
+    ; Check that JSON follows the supported string-key/value object format,
+    ; where each value is either a string or an array of strings.
     static _IsValidSecretsJson(jsonText) {
-        ; Small bounded parser: only { "key": "value" } pairs are allowed here.
+        ; Small bounded parser: only { "key": "value" } / { "key": ["value", ...] } pairs are allowed here.
         position := 1
         this._SkipJsonWhitespace(jsonText, &position)
         if SubStr(jsonText, position, 1) != "{"
@@ -169,9 +182,9 @@ class SecretsFileManager {
 
             position += 1
             this._SkipJsonWhitespace(jsonText, &position)
-            value := this._ConsumeJsonString(jsonText, &position)
-            if value = false
-                return "for property: " . key . " (expected string only)"
+            valueValidation := this._ConsumeJsonValue(jsonText, &position)
+            if valueValidation !== true
+                return "for property: " . key . " (expected a string or an array of strings)"
             this._SkipJsonWhitespace(jsonText, &position)
 
             delimiter := SubStr(jsonText, position, 1)
@@ -186,6 +199,38 @@ class SecretsFileManager {
             position += 1
             this._SkipJsonWhitespace(jsonText, &position)
         }
+    }
+
+    ; Validate one JSON value (a string, or an array of strings) and advance
+    ; the parser position past it. Returns true, or false when invalid.
+    static _ConsumeJsonValue(jsonText, &position) {
+        if SubStr(jsonText, position, 1) = "[" {
+            position += 1
+            this._SkipJsonWhitespace(jsonText, &position)
+            if SubStr(jsonText, position, 1) = "]" {
+                position += 1
+                return true
+            }
+
+            loop {
+                if this._ConsumeJsonString(jsonText, &position) = false
+                    return false
+                this._SkipJsonWhitespace(jsonText, &position)
+
+                delimiter := SubStr(jsonText, position, 1)
+                if delimiter = "]" {
+                    position += 1
+                    return true
+                }
+                if delimiter != ","
+                    return false
+
+                position += 1
+                this._SkipJsonWhitespace(jsonText, &position)
+            }
+        }
+
+        return this._ConsumeJsonString(jsonText, &position) != false
     }
 
     ; Validate one JSON string token and advance the parser position past it.

--- a/Startup/Startup.ahk
+++ b/Startup/Startup.ahk
@@ -21,54 +21,58 @@
 
 RunStartup(profile?) {
     steps := [
-        () => StartNewLogSession(),
-        () => TraySetIcon(Paths.autoHotkeyIcon),
-        () => StartupMessage(),
-        () => StartupMenuTray(),
-        () => SecretsFileManager.Initialize(),
-        () => IsSet(profile) ? ProfileManager.Set(profile) : ProfileManager.SetByComputerName(),
+        { name: "Start new log session", action: () => StartNewLogSession() },
+        { name: "Set startup tray icon", action: () => TraySetIcon(Paths.autoHotkeyIcon) },
+        { name: "Show startup message", action: () => StartupMessage() },
+        { name: "Configure startup tray menu", action: () => StartupMenuTray() },
+        { name: "Initialize secrets", action: () => SecretsFileManager.Initialize() },
+        { name: "Select active profile", action: () => IsSet(profile) ? ProfileManager.Set(profile) : ProfileManager.SetByComputerName() },
 
-        () => Run(Paths.appsStandalone "\Capslock Service.ahk"), ; Run this before scripts that set a capslock hotkey
-        () => Run(Paths.dashboards "\Age of Efficiency\Age of Efficiency.ahk"),
-        () => Run(Paths.dashboards "\Macro Board\Macro Board.ahk"),
+        ; Run this before scripts that set a CapsLock hotkey.
+        { name: "Start Capslock Service", action: () => Run(Paths.appsStandalone "\Capslock Service.ahk") },
+        { name: "Start Age of Efficiency", action: () => Run(Paths.dashboards "\Age of Efficiency\Age of Efficiency.ahk") },
+        { name: "Start Macro Board", action: () => Run(Paths.dashboards "\Macro Board\Macro Board.ahk") },
 
-        () => Run(Paths.appsStandalone "\Desktops Manager\Desktops Manager.ahk"),
-        () => Run(Paths.appsStandalone "\Emoji Sender\Emoji Sender.ahk"),
-        () => Run(Paths.appsStandalone "\Mouse Gestures\Mouse Gestures.ahk"),
-        () => Run(Paths.appsStandalone "\Screen Snipper\Screen Snipper.ahk"),
-        () => Run(Paths.appsStandalone "\Key Bindings.ahk"),
-        () => Run(Paths.appsStandalone "\Text Speaker\Text Speaker.ahk"),
-        () => Run(Paths.appsStandalone "\Window Manager.ahk"),
+        { name: "Start Desktops Manager", action: () => Run(Paths.appsStandalone "\Desktops Manager\Desktops Manager.ahk") },
+        { name: "Start Emoji Sender", action: () => Run(Paths.appsStandalone "\Emoji Sender\Emoji Sender.ahk") },
+        { name: "Start Mouse Gestures", action: () => Run(Paths.appsStandalone "\Mouse Gestures\Mouse Gestures.ahk") },
+        { name: "Start Screen Snipper", action: () => Run(Paths.appsStandalone "\Screen Snipper\Screen Snipper.ahk") },
+        { name: "Start Key Bindings", action: () => Run(Paths.appsStandalone "\Key Bindings.ahk") },
+        { name: "Start Text Speaker", action: () => Run(Paths.appsStandalone "\Text Speaker\Text Speaker.ahk") },
+        { name: "Start Window Manager", action: () => Run(Paths.appsStandalone "\Window Manager.ahk") },
 
-        () => Run(Paths.appsIntegrated "\Command Storer\Command Storer.ahk"),
-        () => Run(Paths.appsIntegrated "\App Hotkeys.ahk"),
-        () => Run(Paths.appsIntegrated "\Hotkeys.ahk"),
-        () => Run(Paths.appsIntegrated "\Mouse Toys.ahk"),
+        { name: "Start Command Storer", action: () => Run(Paths.appsIntegrated "\Command Storer\Command Storer.ahk") },
+        { name: "Start App Hotkeys", action: () => Run(Paths.appsIntegrated "\App Hotkeys.ahk") },
+        { name: "Start Hotkeys", action: () => Run(Paths.appsIntegrated "\Hotkeys.ahk") },
+        { name: "Start Mouse Toys", action: () => Run(Paths.appsIntegrated "\Mouse Toys.ahk") },
+        { name: "Initialize logger", action: () => InitializeLogging() },
     ]
 
-    failuresCounter := 0
+    failures := []
     for step in steps {
         try
-            step()
+            step.action.Call()
         catch as startupError {
-            failuresCounter++
-            LogAndNotifyError("Startup step failed: " startupError.Message,
+            failureMessage := step.name " failed: " startupError.Message
+            failures.Push(failureMessage)
+
+            ; Logging is best-effort here: a broken log path or lock must not
+            ; abort the remaining startup steps or suppress the final dialog.
+            try LogAndNotifyError(failureMessage,
                 startupError.HasProp("Stack") ? startupError.Stack : "")
         }
     }
 
-    try InitializeLogging()
-    catch as loggingError {
-        failuresCounter++
-        LogAndNotifyError("Logger startup failed: " loggingError.Message, loggingError.Stack)
+    if failures.Length {
+        summary := failures.Length " startup step(s) failed:"
+        for failure in failures
+            summary .= "`n`n• " failure
+        MsgBox summary, "AutoHotkey Startup Error", 16
     }
-    
-    if failuresCounter
-        MsgBox failuresCounter " startup step(s) failed. See the error log for details.", "AutoHotkey Startup Error", 16
 }
 
 ; Auto-run only when in Startup folder or run as standalone (not when #Include'd)
-if (StrSplit(A_ScriptDir, "\").Pop() = StrSplit(A_Startup, "\").Pop())     
+if (StrSplit(A_ScriptDir, "\").Pop() = StrSplit(A_Startup, "\").Pop())
     RunStartup()
 
 

--- a/Startup/Startup.ahk
+++ b/Startup/Startup.ahk
@@ -21,7 +21,7 @@
 
 RunStartup(profile?) {
     steps := [
-        () => ClearErrorLog(),
+        () => StartNewLogSession(),
         () => TraySetIcon(Paths.autoHotkeyIcon),
         () => StartupMessage(),
         () => StartupMenuTray(),
@@ -52,11 +52,16 @@ RunStartup(profile?) {
             step()
         catch as startupError {
             failuresCounter++
-            LogAndNotifyError("Startup step failed: " startupError.Message, startupError)
+            LogAndNotifyError("Startup step failed: " startupError.Message,
+                startupError.HasProp("Stack") ? startupError.Stack : "")
         }
     }
 
-    InitializeLogging()
+    try InitializeLogging()
+    catch as loggingError {
+        failuresCounter++
+        LogAndNotifyError("Logger startup failed: " loggingError.Message, loggingError.Stack)
+    }
     
     if failuresCounter
         MsgBox failuresCounter " startup step(s) failed. See the error log for details.", "AutoHotkey Startup Error", 16

--- a/Startup/Startup.ahk
+++ b/Startup/Startup.ahk
@@ -20,39 +20,46 @@
 #Include Startup Menu Tray.ahk
 
 RunStartup(profile?) {
-    try {
-        TraySetIcon(Paths.autoHotkeyIcon)
-        StartupMessage()
-        StartupMenuTray()
-        InitializeLogging()
-        SecretsFileManager.Initialize()
+    steps := [
+        () => ClearErrorLog(),
+        () => TraySetIcon(Paths.autoHotkeyIcon),
+        () => StartupMessage(),
+        () => StartupMenuTray(),
+        () => SecretsFileManager.Initialize(),
+        () => IsSet(profile) ? ProfileManager.Set(profile) : ProfileManager.SetByComputerName(),
 
-        IsSet(profile) ? ProfileManager.Set(profile) : ProfileManager.SetByComputerName()
+        () => Run(Paths.appsStandalone "\Capslock Service.ahk"), ; Run this before scripts that set a capslock hotkey
+        () => Run(Paths.dashboards "\Age of Efficiency\Age of Efficiency.ahk"),
+        () => Run(Paths.dashboards "\Macro Board\Macro Board.ahk"),
 
-        Run(Paths.appsStandalone "\Capslock Service.ahk") ; Run this before scripts that set a capslock hotkey
-        Run(Paths.dashboards "\Age of Efficiency\Age of Efficiency.ahk")
-        Run(Paths.dashboards "\Macro Board\Macro Board.ahk")
+        () => Run(Paths.appsStandalone "\Desktops Manager\Desktops Manager.ahk"),
+        () => Run(Paths.appsStandalone "\Emoji Sender\Emoji Sender.ahk"),
+        () => Run(Paths.appsStandalone "\Mouse Gestures\Mouse Gestures.ahk"),
+        () => Run(Paths.appsStandalone "\Screen Snipper\Screen Snipper.ahk"),
+        () => Run(Paths.appsStandalone "\Key Bindings.ahk"),
+        () => Run(Paths.appsStandalone "\Text Speaker\Text Speaker.ahk"),
+        () => Run(Paths.appsStandalone "\Window Manager.ahk"),
 
-        Run(Paths.appsStandalone "\Desktops Manager\Desktops Manager.ahk")
-        Run(Paths.appsStandalone "\Emoji Sender\Emoji Sender.ahk")
-        Run(Paths.appsStandalone "\Mouse Gestures\Mouse Gestures.ahk")
-        Run(Paths.appsStandalone "\Screen Snipper\Screen Snipper.ahk")
-        Run(Paths.appsStandalone "\Key Bindings.ahk")
-        Run(Paths.appsStandalone "\Text Speaker\Text Speaker.ahk")
-        Run(Paths.appsStandalone "\Window Manager.ahk")
+        () => Run(Paths.appsIntegrated "\Command Storer\Command Storer.ahk"),
+        () => Run(Paths.appsIntegrated "\App Hotkeys.ahk"),
+        () => Run(Paths.appsIntegrated "\Hotkeys.ahk"),
+        () => Run(Paths.appsIntegrated "\Mouse Toys.ahk"),
+    ]
 
-        Run(Paths.appsIntegrated "\Command Storer\Command Storer.ahk")
-        Run(Paths.appsIntegrated "\App Hotkeys.ahk")
-        Run(Paths.appsIntegrated "\Hotkeys.ahk")
-        Run(Paths.appsIntegrated "\Mouse Toys.ahk")
-    } catch as startupError {
-        ; A failure here aborts the rest of RunStartup silently unless we show
-        ; it ourselves - OnError's handler suppresses the modal dialog and only
-        ; logs/notifies, which is easy to miss when nothing else came up.
-        MsgBox("Startup failed and did not finish:`n`n" startupError.Message,
-            "AutoHotkey Startup Error", "IconX")
-        throw startupError
+    failuresCounter := 0
+    for step in steps {
+        try
+            step()
+        catch as startupError {
+            failuresCounter++
+            LogAndNotifyError("Startup step failed: " startupError.Message, startupError)
+        }
     }
+
+    InitializeLogging()
+    
+    if failuresCounter
+        MsgBox failuresCounter " startup step(s) failed. See the error log for details.", "AutoHotkey Startup Error", 16
 }
 
 ; Auto-run only when in Startup folder or run as standalone (not when #Include'd)

--- a/Startup/Startup.ahk
+++ b/Startup/Startup.ahk
@@ -21,39 +21,39 @@
 
 RunStartup(profile?) {
     steps := [
-        { name: "Start new log session", action: () => StartNewLogSession() },
-        { name: "Set startup tray icon", action: () => TraySetIcon(Paths.autoHotkeyIcon) },
-        { name: "Show startup message", action: () => StartupMessage() },
-        { name: "Configure startup tray menu", action: () => StartupMenuTray() },
-        { name: "Initialize secrets", action: () => SecretsFileManager.Initialize() },
-        { name: "Select active profile", action: () => IsSet(profile) ? ProfileManager.Set(profile) : ProfileManager.SetByComputerName() },
+        () => StartNewLogSession(),
+        () => TraySetIcon(Paths.autoHotkeyIcon),
+        () => StartupMessage(),
+        () => StartupMenuTray(),
+        () => SecretsFileManager.Initialize(),
+        () => IsSet(profile) ? ProfileManager.Set(profile) : ProfileManager.SetByComputerName(),
 
         ; Run this before scripts that set a CapsLock hotkey.
-        { name: "Start Capslock Service", action: () => Run(Paths.appsStandalone "\Capslock Service.ahk") },
-        { name: "Start Age of Efficiency", action: () => Run(Paths.dashboards "\Age of Efficiency\Age of Efficiency.ahk") },
-        { name: "Start Macro Board", action: () => Run(Paths.dashboards "\Macro Board\Macro Board.ahk") },
+        () => Run(Paths.appsStandalone "\Capslock Service.ahk"),
+        () => Run(Paths.dashboards "\Age of Efficiency\Age of Efficiency.ahk"),
+        () => Run(Paths.dashboards "\Macro Board\Macro Board.ahk"),
 
-        { name: "Start Desktops Manager", action: () => Run(Paths.appsStandalone "\Desktops Manager\Desktops Manager.ahk") },
-        { name: "Start Emoji Sender", action: () => Run(Paths.appsStandalone "\Emoji Sender\Emoji Sender.ahk") },
-        { name: "Start Mouse Gestures", action: () => Run(Paths.appsStandalone "\Mouse Gestures\Mouse Gestures.ahk") },
-        { name: "Start Screen Snipper", action: () => Run(Paths.appsStandalone "\Screen Snipper\Screen Snipper.ahk") },
-        { name: "Start Key Bindings", action: () => Run(Paths.appsStandalone "\Key Bindings.ahk") },
-        { name: "Start Text Speaker", action: () => Run(Paths.appsStandalone "\Text Speaker\Text Speaker.ahk") },
-        { name: "Start Window Manager", action: () => Run(Paths.appsStandalone "\Window Manager.ahk") },
+        () => Run(Paths.appsStandalone "\Desktops Manager\Desktops Manager.ahk"),
+        () => Run(Paths.appsStandalone "\Emoji Sender\Emoji Sender.ahk"),
+        () => Run(Paths.appsStandalone "\Mouse Gestures\Mouse Gestures.ahk"),
+        () => Run(Paths.appsStandalone "\Screen Snipper\Screen Snipper.ahk"),
+        () => Run(Paths.appsStandalone "\Key Bindings.ahk"),
+        () => Run(Paths.appsStandalone "\Text Speaker\Text Speaker.ahk"),
+        () => Run(Paths.appsStandalone "\Window Manager.ahk"),
 
-        { name: "Start Command Storer", action: () => Run(Paths.appsIntegrated "\Command Storer\Command Storer.ahk") },
-        { name: "Start App Hotkeys", action: () => Run(Paths.appsIntegrated "\App Hotkeys.ahk") },
-        { name: "Start Hotkeys", action: () => Run(Paths.appsIntegrated "\Hotkeys.ahk") },
-        { name: "Start Mouse Toys", action: () => Run(Paths.appsIntegrated "\Mouse Toys.ahk") },
-        { name: "Initialize logger", action: () => InitializeLogging() },
+        () => Run(Paths.appsIntegrated "\Command Storer\Command Storer.ahk"),
+        () => Run(Paths.appsIntegrated "\App Hotkeys.ahk"),
+        () => Run(Paths.appsIntegrated "\Hotkeys.ahk"),
+        () => Run(Paths.appsIntegrated "\Mouse Toys.ahk"),
+        () => InitializeLogging(),
     ]
 
     failures := []
     for step in steps {
         try
-            step.action.Call()
+            step.Call()
         catch as startupError {
-            failureMessage := step.name " failed: " startupError.Message
+            failureMessage := "Startup step failed: " startupError.Message
             failures.Push(failureMessage)
 
             ; Logging is best-effort here: a broken log path or lock must not
@@ -74,5 +74,4 @@ RunStartup(profile?) {
 ; Auto-run only when in Startup folder or run as standalone (not when #Include'd)
 if (StrSplit(A_ScriptDir, "\").Pop() = StrSplit(A_Startup, "\").Pop())
     RunStartup()
-
 

--- a/Startup/Startup.ahk
+++ b/Startup/Startup.ahk
@@ -20,30 +20,39 @@
 #Include Startup Menu Tray.ahk
 
 RunStartup(profile?) {
-    TraySetIcon(Paths.autoHotkeyIcon)
-    StartupMessage()
-    StartupMenuTray()
-    InitializeLogging()
-    SecretsFileManager.Initialize()
+    try {
+        TraySetIcon(Paths.autoHotkeyIcon)
+        StartupMessage()
+        StartupMenuTray()
+        InitializeLogging()
+        SecretsFileManager.Initialize()
 
-    IsSet(profile) ? ProfileManager.Set(profile) : ProfileManager.SetByComputerName()
+        IsSet(profile) ? ProfileManager.Set(profile) : ProfileManager.SetByComputerName()
 
-    Run(Paths.appsStandalone "\Capslock Service.ahk") ; Run this before scripts that set a capslock hotkey
-    Run(Paths.dashboards "\Age of Efficiency\Age of Efficiency.ahk")
-    Run(Paths.dashboards "\Macro Board\Macro Board.ahk")
+        Run(Paths.appsStandalone "\Capslock Service.ahk") ; Run this before scripts that set a capslock hotkey
+        Run(Paths.dashboards "\Age of Efficiency\Age of Efficiency.ahk")
+        Run(Paths.dashboards "\Macro Board\Macro Board.ahk")
 
-    Run(Paths.appsStandalone "\Desktops Manager\Desktops Manager.ahk")
-    Run(Paths.appsStandalone "\Emoji Sender\Emoji Sender.ahk")
-    Run(Paths.appsStandalone "\Mouse Gestures\Mouse Gestures.ahk")
-    Run(Paths.appsStandalone "\Screen Snipper\Screen Snipper.ahk")
-    Run(Paths.appsStandalone "\Key Bindings.ahk")
-    Run(Paths.appsStandalone "\Text Speaker\Text Speaker.ahk")
-    Run(Paths.appsStandalone "\Window Manager.ahk")
+        Run(Paths.appsStandalone "\Desktops Manager\Desktops Manager.ahk")
+        Run(Paths.appsStandalone "\Emoji Sender\Emoji Sender.ahk")
+        Run(Paths.appsStandalone "\Mouse Gestures\Mouse Gestures.ahk")
+        Run(Paths.appsStandalone "\Screen Snipper\Screen Snipper.ahk")
+        Run(Paths.appsStandalone "\Key Bindings.ahk")
+        Run(Paths.appsStandalone "\Text Speaker\Text Speaker.ahk")
+        Run(Paths.appsStandalone "\Window Manager.ahk")
 
-    Run(Paths.appsIntegrated "\Command Storer\Command Storer.ahk")
-    Run(Paths.appsIntegrated "\App Hotkeys.ahk")
-    Run(Paths.appsIntegrated "\Hotkeys.ahk")
-    Run(Paths.appsIntegrated "\Mouse Toys.ahk")
+        Run(Paths.appsIntegrated "\Command Storer\Command Storer.ahk")
+        Run(Paths.appsIntegrated "\App Hotkeys.ahk")
+        Run(Paths.appsIntegrated "\Hotkeys.ahk")
+        Run(Paths.appsIntegrated "\Mouse Toys.ahk")
+    } catch as startupError {
+        ; A failure here aborts the rest of RunStartup silently unless we show
+        ; it ourselves - OnError's handler suppresses the modal dialog and only
+        ; logs/notifies, which is easy to miss when nothing else came up.
+        MsgBox("Startup failed and did not finish:`n`n" startupError.Message,
+            "AutoHotkey Startup Error", "IconX")
+        throw startupError
+    }
 }
 
 ; Auto-run only when in Startup folder or run as standalone (not when #Include'd)

--- a/Tests/Integration/Logging.Integration.Tests.ahk
+++ b/Tests/Integration/Logging.Integration.Tests.ahk
@@ -133,7 +133,7 @@ Test_RealHostsAndCrossProcessBehavior() {
 		ShowLogDashboard()
 		dashboardPid := WinGetPID("ahk_id " FindLogDashboardWindow())
 		Assert.NotEqual(loggerPid, dashboardPid, "Logger and dashboard must have separate host processes")
-		Assert.True(IsVisible(FindLogDashboardWindow()), "Client API should show shared dashboard")
+		Assert.True(WaitUntil(() => IsVisible(FindLogDashboardWindow())), "Client API should show shared dashboard")
 		Assert.True(WaitUntil(() => !IsVisible(FindLoggerWindow())), "Opening dashboard should hide logger; read=" GetReadLogEntryCount() ", total=" GetLogEntryCount() DumpEntries())
 		Assert.Equal(0, GetUnreadLogEntries().Length, "Opening dashboard should mark all logs read")
 		HideLogDashboard()

--- a/Tests/Integration/Logging.Integration.Tests.ahk
+++ b/Tests/Integration/Logging.Integration.Tests.ahk
@@ -69,12 +69,14 @@ Test_RealHostsAndCrossProcessBehavior() {
 	loggerPid := 0
 	dashboardPid := 0
 	try {
+		; Entries written before the popup exists must be surfaced on its first poll.
+		LogAndNotifyWarning("logged before logger host startup")
 		hosts := InitializeLogging()
 		loggerPid := WinGetPID("ahk_id " hosts["logger"])
-		dashboardPid := WinGetPID("ahk_id " hosts["dashboard"])
-		Assert.NotEqual(loggerPid, dashboardPid, "Logger and dashboard must have separate host processes")
-		Assert.False(IsVisible(hosts["logger"]), "Logger starts hidden")
-		Assert.False(IsVisible(hosts["dashboard"]), "Dashboard starts hidden")
+		Assert.False(FindLogDashboardWindow(), "Dashboard is lazy and must not start with the Logger")
+		Assert.Equal(hosts["logger"], EnsureLoggerRunning(), "Logger initialization reuses the existing host")
+		Assert.Equal(loggerPid, WinGetPID("ahk_id " FindLoggerWindow()), "Reusing the Logger must preserve its process")
+		Assert.True(WaitUntil(() => IsVisible(FindLoggerWindow())), "A notifying entry written before host startup must be surfaced")
 
 		; Confirmed via a diagnostic dump of the actual log on a real CI
 		; failure: both hosts independently trigger a
@@ -115,8 +117,10 @@ Test_RealHostsAndCrossProcessBehavior() {
 		Assert.Equal(1, GetUnreadLogCounts()["warning"])
 
 		ShowLogDashboard()
+		dashboardPid := WinGetPID("ahk_id " FindLogDashboardWindow())
+		Assert.NotEqual(loggerPid, dashboardPid, "Logger and dashboard must have separate host processes")
 		Assert.True(IsVisible(FindLogDashboardWindow()), "Client API should show shared dashboard")
-		Assert.True(WaitUntil(() => !IsVisible(FindLoggerWindow())), "Opening dashboard should hide logger")
+		Assert.True(WaitUntil(() => !IsVisible(FindLoggerWindow())), "Opening dashboard should hide logger; read=" GetReadLogEntryCount() ", total=" GetLogEntryCount() DumpEntries())
 		Assert.Equal(0, GetUnreadLogEntries().Length, "Opening dashboard should mark all logs read")
 		HideLogDashboard()
 		Assert.False(IsVisible(FindLogDashboardWindow()), "Client API should hide shared dashboard")
@@ -136,7 +140,32 @@ Test_RealHostsAndCrossProcessBehavior() {
 	}
 }
 
+Test_ConcurrentWritersPreserveEveryEntry() {
+	ClearErrorLog()
+	writerCount := 4
+	entriesPerWriter := 10
+	pids := []
+	writerScript := A_ScriptDir "\..\Support\LoggingWriter.ahk"
+
+	loop writerCount {
+		Run('"' A_AhkPath '" /ErrorStdOut "' writerScript '" "writer-' A_Index '" "' entriesPerWriter '"',,, &pid)
+		pids.Push(pid)
+	}
+	for pid in pids
+		Assert.True(WaitUntil(() => !ProcessExist(pid), 30000), "Concurrent log writer did not exit")
+
+	entries := ReadLogEntries()
+	Assert.Equal(writerCount * entriesPerWriter, entries.Length, "Every concurrent append must produce one valid entry")
+	seen := Map()
+	for entry in entries {
+		message := entry["message"]
+		Assert.False(seen.Has(message), "Duplicate concurrent log entry: " message)
+		seen[message] := true
+	}
+}
+
 TestKit.Run("Real hosts, unread state, show/hide API, and overlapping timers", Test_RealHostsAndCrossProcessBehavior)
+TestKit.Run("Concurrent writer processes preserve every JSONL entry exactly once", Test_ConcurrentWritersPreserveEveryEntry)
 TestKit.Report()
 
 #Include ..\Support\Assert.ahk

--- a/Tests/Integration/Logging.Integration.Tests.ahk
+++ b/Tests/Integration/Logging.Integration.Tests.ahk
@@ -107,6 +107,20 @@ Test_RealHostsAndCrossProcessBehavior() {
 		Assert.True(WaitUntil(() => !IsVisible(FindLoggerWindow())), "Logger should hide once existing entries are marked read")
 		ClearErrorLog()
 
+		; A new session with the same number of entries must not inherit the old
+		; processing cursor. Entry count alone cannot distinguish this rotation.
+		LogAndNotifyWarning("before equal-count rotation")
+		Assert.True(WaitUntil(() => IsVisible(FindLoggerWindow())), "Pre-rotation notification should be processed")
+		MarkAllLogsRead()
+		Assert.True(WaitUntil(() => !IsVisible(FindLoggerWindow())), "Pre-rotation notification should dismiss")
+		StartNewLogSession()
+		LogAndNotifyError("after equal-count rotation")
+		Assert.True(WaitUntil(() => IsVisible(FindLoggerWindow())), "A notifying entry must be processed after an equal-count rotation")
+		Assert.Equal(1, GetUnreadLogCounts()["error"])
+		MarkAllLogsRead()
+		Assert.True(WaitUntil(() => !IsVisible(FindLoggerWindow())), "Post-rotation notification should dismiss")
+		ClearErrorLog()
+
 		LogInfo("silent unread info")
 		Sleep(1250)
 		Assert.False(IsVisible(FindLoggerWindow()), "LogInfo increments unread state without notifying." DumpEntries())

--- a/Tests/Support/LoggingWriter.ahk
+++ b/Tests/Support/LoggingWriter.ahk
@@ -1,0 +1,14 @@
+#Requires AutoHotkey v2
+#SingleInstance Off
+#Include ..\..\Lib\Core\OnError.ahk
+
+try {
+	writerId := A_Args[1]
+	entryCount := Integer(A_Args[2])
+	loop entryCount
+		LogInfo(writerId "-" A_Index)
+	ExitApp(0)
+} catch as writerError {
+	FileAppend(writerId ": " writerError.Message "`n" writerError.Stack "`n", "**")
+	ExitApp(2)
+}

--- a/Tests/Unit/Logging.Tests.ahk
+++ b/Tests/Unit/Logging.Tests.ahk
@@ -85,12 +85,14 @@ Test_InvalidReadStateFallsBackToZero() {
 
 Test_ClearRemovesLogAndReadState() {
 	ResetLogFiles()
+	previousSessionId := GetLogSessionId()
 	LogInfo("entry")
 	MarkAllLogsRead()
 	ClearErrorLog()
 	Assert.False(FileExist(ErrorLogFile()))
 	Assert.False(FileExist(ErrorLogReadStateFile()))
 	Assert.Equal(0, GetUnreadLogEntries().Length)
+	Assert.NotEqual(previousSessionId, GetLogSessionId(), "Clearing the log must start a distinct session")
 }
 
 Test_UnreadCountsIgnoreUnknownSeverities() {
@@ -164,6 +166,7 @@ Test_AppendRejectsNonStringStack() {
 Test_StartNewSessionArchivesActiveLogAndResetsReadState() {
 	ResetLogFiles()
 	ClearLogArchivesForTest()
+	previousSessionId := GetLogSessionId()
 	LogInfo("previous session")
 	MarkAllLogsRead()
 	StartNewLogSession()
@@ -174,6 +177,7 @@ Test_StartNewSessionArchivesActiveLogAndResetsReadState() {
 		archives.Push(A_LoopFileFullPath)
 	Assert.Equal(1, archives.Length)
 	Assert.True(InStr(FileRead(archives[1], "UTF-8"), "previous session") > 0)
+	Assert.NotEqual(previousSessionId, GetLogSessionId(), "Rotating the log must start a distinct session")
 }
 
 Test_StartNewSessionAvoidsArchiveNameCollisions() {

--- a/Tests/Unit/Logging.Tests.ahk
+++ b/Tests/Unit/Logging.Tests.ahk
@@ -9,6 +9,13 @@ EnvSet("AUTOHOTKEY_BASE", testRoot)
 
 ResetLogFiles() => ClearErrorLog()
 
+ClearLogArchivesForTest() {
+	if !DirExist(ErrorLogArchiveDirectory())
+		return
+	loop files ErrorLogArchiveDirectory() "\*", "F"
+		FileDelete(A_LoopFileFullPath)
+}
+
 Test_AppendWritesStructuredEntry() {
 	ResetLogFiles()
 	LogInfo("hello")
@@ -136,6 +143,91 @@ Test_HandleUnhandledErrorOmitsStackWhenAbsent() {
 	Assert.Equal("", ReadLogEntries()[1]["stack"])
 }
 
+Test_HandleUnhandledErrorFallsBackWhenPersistenceFails() {
+	blockingFile := testRoot "\not-a-directory"
+	FileAppend("block directory creation", blockingFile, "UTF-8")
+	EnvSet("AUTOHOTKEY_LOG_DIR", blockingFile)
+	try {
+		Assert.False(HandleUnhandledError(Error("must remain visible"), "Return"),
+			"Default AutoHotkey reporting must not be suppressed when logging fails")
+	} finally {
+		EnvSet("AUTOHOTKEY_LOG_DIR", "")
+	}
+}
+
+Test_AppendRejectsNonStringStack() {
+	ResetLogFiles()
+	Assert.Throws(() => LogError("bad stack", Error("nested")), "A non-string stack must throw")
+	Assert.Equal(0, GetLogEntryCount())
+}
+
+Test_StartNewSessionArchivesActiveLogAndResetsReadState() {
+	ResetLogFiles()
+	ClearLogArchivesForTest()
+	LogInfo("previous session")
+	MarkAllLogsRead()
+	StartNewLogSession()
+	Assert.False(FileExist(ErrorLogFile()))
+	Assert.False(FileExist(ErrorLogReadStateFile()))
+	archives := []
+	loop files ErrorLogArchiveDirectory() "\errors-*.log", "F"
+		archives.Push(A_LoopFileFullPath)
+	Assert.Equal(1, archives.Length)
+	Assert.True(InStr(FileRead(archives[1], "UTF-8"), "previous session") > 0)
+}
+
+Test_StartNewSessionAvoidsArchiveNameCollisions() {
+	ResetLogFiles()
+	ClearLogArchivesForTest()
+	LogInfo("first")
+	StartNewLogSession()
+	LogInfo("second")
+	StartNewLogSession()
+	archiveCount := 0
+	loop files ErrorLogArchiveDirectory() "\errors-*.log", "F"
+		archiveCount++
+	Assert.Equal(2, archiveCount)
+}
+
+Test_StartNewSessionPrunesOldestArchives() {
+	ResetLogFiles()
+	ClearLogArchivesForTest()
+	loop 4 {
+		LogInfo("session " A_Index)
+		StartNewLogSession(2)
+	}
+	archives := []
+	loop files ErrorLogArchiveDirectory() "\errors-*.log", "F"
+		archives.Push(FileRead(A_LoopFileFullPath, "UTF-8"))
+	Assert.Equal(2, archives.Length)
+	combined := archives[1] archives[2]
+	Assert.False(InStr(combined, "session 1") > 0)
+	Assert.False(InStr(combined, "session 2") > 0)
+	Assert.True(InStr(combined, "session 3") > 0)
+	Assert.True(InStr(combined, "session 4") > 0)
+}
+
+Test_UnreadCountsCanUseOneEntriesSnapshot() {
+	ResetLogFiles()
+	LogInfo("in snapshot")
+	snapshot := ReadLogEntries()
+	LogWarning("after snapshot")
+	counts := GetUnreadLogCounts(snapshot)
+	Assert.Equal(1, counts["info"])
+	Assert.Equal(0, counts["warning"])
+	Assert.Equal(2, GetUnreadLogEntries().Length, "Default API still reads the latest file state")
+}
+
+Test_SharedParserValidatesArbitraryLogFile() {
+	ResetLogFiles()
+	fixture := testRoot "\parser-fixture.log"
+	FileAppend("malformed`n", fixture, "UTF-8")
+	FileAppend('{"severity":"warning","message":"valid"}`n', fixture, "UTF-8")
+	entries := ReadLogEntriesFromFile(fixture)
+	Assert.Equal(1, entries.Length)
+	Assert.Equal("valid", entries[1]["message"])
+}
+
 TestKit.Run("Append writes a structured non-notifying entry", Test_AppendWritesStructuredEntry)
 TestKit.Run("LogAndNotify variants set notify and preserve stack", Test_NotifyVariantsSetNotifyFlag)
 TestKit.Run("Unread counts include info, warning, and error logs", Test_UnreadCountsAllSeverities)
@@ -148,5 +240,12 @@ TestKit.Run("AUTOHOTKEY_LOG_DIR overrides the default log directory", Test_LogDi
 TestKit.Run("HandleUnhandledError logs a notifying error and suppresses the dialog", Test_HandleUnhandledErrorLogsNotifyingErrorAndSuppressesDialog)
 TestKit.Run("HandleUnhandledError includes the error's stack when present", Test_HandleUnhandledErrorIncludesStackWhenPresent)
 TestKit.Run("HandleUnhandledError omits the stack when absent", Test_HandleUnhandledErrorOmitsStackWhenAbsent)
+TestKit.Run("HandleUnhandledError preserves default reporting when persistence fails", Test_HandleUnhandledErrorFallsBackWhenPersistenceFails)
+TestKit.Run("Append rejects a non-string stack before persistence", Test_AppendRejectsNonStringStack)
+TestKit.Run("New session archives the active log and resets read state", Test_StartNewSessionArchivesActiveLogAndResetsReadState)
+TestKit.Run("Rapid session rotation avoids archive name collisions", Test_StartNewSessionAvoidsArchiveNameCollisions)
+TestKit.Run("Session rotation prunes the oldest archives", Test_StartNewSessionPrunesOldestArchives)
+TestKit.Run("Unread counts can reuse a single entries snapshot", Test_UnreadCountsCanUseOneEntriesSnapshot)
+TestKit.Run("Shared parser validates an arbitrary JSONL log file", Test_SharedParserValidatesArbitraryLogFile)
 
 TestKit.Report()

--- a/Tests/Unit/Logging.Tests.ahk
+++ b/Tests/Unit/Logging.Tests.ahk
@@ -222,6 +222,16 @@ Test_UnreadCountsCanUseOneEntriesSnapshot() {
 	Assert.Equal(2, GetUnreadLogEntries().Length, "Default API still reads the latest file state")
 }
 
+Test_ReadLogStateReturnsOneConsistentSnapshot() {
+	ResetLogFiles()
+	LogInfo("read")
+	MarkAllLogsRead()
+	state := ReadLogState()
+	Assert.Equal(1, state["entries"].Length)
+	Assert.Equal(1, state["readEntryCount"])
+	Assert.Equal(GetLogSessionId(), state["sessionId"])
+}
+
 Test_SharedParserValidatesArbitraryLogFile() {
 	ResetLogFiles()
 	fixture := testRoot "\parser-fixture.log"
@@ -250,6 +260,7 @@ TestKit.Run("New session archives the active log and resets read state", Test_St
 TestKit.Run("Rapid session rotation avoids archive name collisions", Test_StartNewSessionAvoidsArchiveNameCollisions)
 TestKit.Run("Session rotation prunes the oldest archives", Test_StartNewSessionPrunesOldestArchives)
 TestKit.Run("Unread counts can reuse a single entries snapshot", Test_UnreadCountsCanUseOneEntriesSnapshot)
+TestKit.Run("Log state returns entries, cursor, and session as one snapshot", Test_ReadLogStateReturnsOneConsistentSnapshot)
 TestKit.Run("Shared parser validates an arbitrary JSONL log file", Test_SharedParserValidatesArbitraryLogFile)
 
 TestKit.Report()

--- a/Tests/Unit/SecretsFileManager.Tests.ahk
+++ b/Tests/Unit/SecretsFileManager.Tests.ahk
@@ -24,6 +24,10 @@ TestKit.Run("Valid: single string key-value pair", () => Assert.True(SecretsFile
 TestKit.Run("Valid: multiple string key-value pairs", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"a": "1", "b": "2"}')))
 TestKit.Run("Valid: tolerates surrounding whitespace and newlines", () => Assert.True(SecretsFileManager._IsValidSecretsJson("`n  { `"a`" : `"1`" } `n")))
 TestKit.Run("Valid: string values may contain escape sequences", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"a": "line1\nline2\ttabbed"}')))
+TestKit.Run("Valid: array-of-strings value", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": ["secret1", "secret2"]}')))
+TestKit.Run("Valid: empty array value", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": []}')))
+TestKit.Run("Valid: single-element array value", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": ["secret1"]}')))
+TestKit.Run("Valid: mix of string and array values", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"a": "1", "b": ["2", "3"]}')))
 
 TestKit.Run("Invalid: top-level array is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson("[]") != true))
 TestKit.Run("Invalid: numeric value is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": 123}') != true))
@@ -34,6 +38,41 @@ TestKit.Run("Invalid: missing colon is rejected", () => Assert.True(SecretsFileM
 TestKit.Run("Invalid: unterminated string is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": "value') != true))
 TestKit.Run("Invalid: empty text is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson("") != true))
 TestKit.Run("Invalid: trailing garbage after the closing brace is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key":"value"}garbage') != true))
+TestKit.Run("Invalid: array with a non-string element is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": ["a", 1]}') != true))
+TestKit.Run("Invalid: array with a nested array is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": ["a", []]}') != true))
+TestKit.Run("Invalid: array with trailing comma is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": ["a",]}') != true))
+TestKit.Run("Invalid: unterminated array is rejected", () => Assert.True(SecretsFileManager._IsValidSecretsJson('{"key": ["a", "b"}') != true))
+
+Test_IsValidSecretValue_AcceptsString() {
+    Assert.True(SecretsFileManager._IsValidSecretValue("value"))
+}
+
+Test_IsValidSecretValue_AcceptsArrayOfStrings() {
+    Assert.True(SecretsFileManager._IsValidSecretValue(["secret1", "secret2"]))
+}
+
+Test_IsValidSecretValue_AcceptsEmptyArray() {
+    Assert.True(SecretsFileManager._IsValidSecretValue([]))
+}
+
+Test_IsValidSecretValue_RejectsArrayWithNonStringElement() {
+    Assert.True(SecretsFileManager._IsValidSecretValue(["a", 1]) != true)
+}
+
+Test_IsValidSecretValue_RejectsNumber() {
+    Assert.True(SecretsFileManager._IsValidSecretValue(123) != true)
+}
+
+Test_IsValidSecretValue_RejectsMap() {
+    Assert.True(SecretsFileManager._IsValidSecretValue(Map()) != true)
+}
+
+TestKit.Run("IsValidSecretValue accepts a string", Test_IsValidSecretValue_AcceptsString)
+TestKit.Run("IsValidSecretValue accepts an array of strings", Test_IsValidSecretValue_AcceptsArrayOfStrings)
+TestKit.Run("IsValidSecretValue accepts an empty array", Test_IsValidSecretValue_AcceptsEmptyArray)
+TestKit.Run("IsValidSecretValue rejects an array with a non-string element", Test_IsValidSecretValue_RejectsArrayWithNonStringElement)
+TestKit.Run("IsValidSecretValue rejects a number", Test_IsValidSecretValue_RejectsNumber)
+TestKit.Run("IsValidSecretValue rejects a map", Test_IsValidSecretValue_RejectsMap)
 
 Test_AhkStringLiteral_EscapesEmbeddedDoubleQuotes() {
     backtick := Chr(96), quote := Chr(34)


### PR DESCRIPTION
## Summary

- Fixes #67: a startup-critical exception (e.g. invalid `secrets.json`) aborted `RunStartup()` silently. `OnError`'s global handler suppresses the modal dialog by design, logging/notifying only, so nothing indicated startup had failed or why. `RunStartup()` now wraps its body in try/catch and shows a `MsgBox` with the error before rethrowing.
- Fixes #68: the Logger popup didn't reliably show info/warning/error entries logged during startup. `LoggerPopup._OnPageReady()` existed to defer polling until the WebView2 page finished loading (per its own comment), but nothing ever called it — `__New()` started polling immediately instead, letting `_Poll()`'s first tick race the page load and silently drop early log entries. `NavigationCompleted` is now wired up to call `_OnPageReady()`, and the premature `_PushState()`/`SetTimer()` calls were removed from `__New()`.
- Allows secret values in `My Secrets.json`/`Removed Secrets.json` to be an array of strings (e.g. `"key": ["secret1", "secret2"]`), not just a plain string. Extended the bounded JSON validator (`_ConsumeJsonValue`) and the catalog-sync type checks (`_IsValidSecretValue`) accordingly, with unit test coverage for valid/invalid array shapes.
- Surfaces secrets-file failures at the point of use, not just at startup: `RunStartup()`'s `MsgBox` only covers the first `SecretsFileManager.Initialize()` call made during startup itself. Any other script that accesses a secret later (each `Run()` call launches a separate AHK process) hit the same throw with no visible feedback, since that process's own `OnError` handler just logs quietly. `SecretsFileManager` now caches an init failure so repeated calls fail fast instead of re-parsing every time, and `Secret.Get()`/`Secret.GetOrSet()` catch it and report through `LogAndNotifyError` (visible via the Logger popup) instead of throwing further, returning `""` so the caller doesn't crash outright.

## Test plan

- [x] Corrupt `Secrets/My Secrets.json` with invalid JSON and run `Startup.ahk` — confirm a visible error dialog appears instead of a silent no-op.
- [ ] Run `Startup.ahk` and confirm info/warning/error log entries generated during startup pop the Logger window.
- [ ] Set a secret value to `["a", "b"]` in `My Secrets.json` and confirm `SecretsFileManager.Initialize()` accepts it without throwing.
- [ ] With `My Secrets.json` still invalid, call `Secrets.SomeSecret.Get()` from a separate script (e.g. one of the `Run()`-launched apps) and confirm it logs/notifies via the Logger popup and returns `""` instead of crashing that script.
- [x] `Tests/Unit/SecretsFileManager.Tests.ahk` passes, including the new array-value cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtnU96UAe7mvXbpGVnkYq2
