### PR TITLE
Open a changelog PR instead of pushing to protected main

### DIFF
--- a/.github/scripts/Update-Changelog.ps1
+++ b/.github/scripts/Update-Changelog.ps1
@@ -9,13 +9,20 @@ history, which is expected - documented in the ticket as acceptable v1
 behavior rather than something to special-case away.
 
 Only writes CHANGELOG.md - does not commit or push. The workflow handles
-git add/commit/push, since that's a workflow-level concern (committer
-identity, no-op detection via `git diff --cached`) rather than something
-this script needs to know about.
+git add/commit/push and the changelog pull request, since those are
+workflow-level concerns (committer identity, no-op detection via
+`git diff --cached`, PR create-vs-reuse) rather than something this
+script needs to know about.
+
+Excludes merged PRs from $ChangelogBranch itself, since main's ruleset
+means every changelog update now lands via a bot-owned pull request from
+that branch - without the exclusion, each merged changelog PR would add
+an entry for itself the next time this script runs.
 #>
 param(
     [Parameter(Mandatory)] [string]$Repo,   # e.g. "Flop0333/AutoHotkey"
-    [string]$ChangelogPath = "CHANGELOG.md"
+    [string]$ChangelogPath = "CHANGELOG.md",
+    [string]$ChangelogBranch = "automation/update-changelog"
 )
 
 $ErrorActionPreference = "Stop"
@@ -33,9 +40,9 @@ if (Test-Path $ChangelogPath) {
     $existingBody = $content -replace ('(?s)^.*?' + [regex]::Escape($MarkerPrefix) + '\d+\s*-->\s*\r?\n?'), ''
 }
 
-$lines = gh pr list --repo $Repo --state merged --json number,title,mergedAt,labels,url --limit 200
+$lines = gh pr list --repo $Repo --state merged --json number,title,mergedAt,labels,url,headRefName --limit 200
 $parsed = ($lines -join "`n") | ConvertFrom-Json
-$allMerged = @($parsed)
+$allMerged = @($parsed | Where-Object { $_.headRefName -ne $ChangelogBranch })
 $newPrs = @($allMerged | Where-Object { $_.number -gt $lastPr } | Sort-Object number)
 
 if ($newPrs.Count -eq 0) {

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,11 +1,15 @@
 name: Update changelog
 
-# Commits straight to main rather than opening a PR: a changelog entry is a
-# pure, easily-revertable text addition (not code), and pushes made with
-# the default GITHUB_TOKEN don't trigger other `push`-type workflow runs,
-# so this can't recurse into itself through GitHub's own anti-recursion
-# rule. The commit-message check below is a second, explicit guard against
-# that in case that assumption ever changes.
+# Opens/updates a bot-owned pull request rather than pushing straight to
+# main, because the main-branch ruleset requires changes to land through a
+# pull request. See issue #89 - the previous direct-push design (see this
+# workflow's git history) failed every run once that ruleset was added.
+#
+# The branch name below is reused across runs (never a per-run/dated
+# name): the branch is fully regenerated from main's current CHANGELOG.md
+# on every run and force-pushed, so there is at most one open changelog PR
+# at a time, and Update-Changelog.ps1 excludes that branch's own merged
+# PRs from future changelog entries (see its header).
 #
 # On its very first run there's no CHANGELOG.md yet, so it back-fills the
 # entire merged-PR history in one section - see Update-Changelog.ps1's
@@ -16,28 +20,49 @@ on:
     branches: [main]
   workflow_dispatch: {}
 
+env:
+  CHANGELOG_BRANCH: automation/update-changelog
+
 jobs:
   changelog:
-    if: "!startsWith(github.event.head_commit.message, 'docs: update changelog')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
       - shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./.github/scripts/Update-Changelog.ps1 -Repo "${{ github.repository }}"
+        run: ./.github/scripts/Update-Changelog.ps1 -Repo "${{ github.repository }}" -ChangelogBranch "${{ env.CHANGELOG_BRANCH }}"
 
-      - name: Commit changelog if changed
+      - name: Open or update changelog pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # `git add` first so a brand-new (untracked) CHANGELOG.md on the
+          # very first run is detected too - plain `git diff` ignores
+          # untracked files.
           git add CHANGELOG.md
           if git diff --cached --quiet; then
             echo "No changelog changes."
+            exit 0
+          fi
+
+          git checkout -B "$CHANGELOG_BRANCH"
+          git commit -m "docs: update changelog"
+          git push --force origin "$CHANGELOG_BRANCH"
+
+          existing=$(gh pr list --repo "${{ github.repository }}" --head "$CHANGELOG_BRANCH" --state open --json number --jq 'length')
+          if [ "$existing" -eq 0 ]; then
+            gh pr create --repo "${{ github.repository }}" \
+              --base main --head "$CHANGELOG_BRANCH" \
+              --title "docs: update changelog" \
+              --body "Automated changelog update from merged pull requests. Never auto-merged - review and merge by hand."
           else
-            git commit -m "docs: update changelog"
-            git push
+            echo "Existing changelog PR updated by the force-push above."
           fi


### PR DESCRIPTION
## Summary
- Replaces the direct `git push` to `main` in `update-changelog.yml` with a bot-owned pull request flow, since the main-branch ruleset requires PRs and every run has been failing.
- The `automation/update-changelog` branch is fully regenerated from `main` and force-pushed each run, so there is at most one open changelog PR at a time; it is only ever created once, then updated by later pushes.
- `Update-Changelog.ps1` now excludes that branch's own merged PRs from future changelog entries, so a merged changelog PR doesn't add a line for itself the next run.
- The changelog PR is never auto-merged - a human reviews and merges it like any other PR.

## Validation
- `git diff --check` passes.
- No existing tests cover `.github/workflows` or `.github/scripts` (confirmed via grep), so this is validated by inspection plus a manual `workflow_dispatch` run against the current `CHANGELOG.md` state (see PR comments once run).

Implements #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)